### PR TITLE
ci: enable production smoke schedule

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,54 @@
+# GitHub loads scheduled workflows from the default branch (master). Keep this
+# file on master; each job checks out develop, the branch deployed to production.
+name: Production smoke
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-smoke
+  cancel-in-progress: false
+
+jobs:
+  statistics:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      VIGIEAU_STATISTICS_DEADLINE: "06:00"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Verify statistics smoke deadline policy
+        run: npm run test:smoke-statistics
+      - name: Public statistics consistency
+        run: node scripts/smoke-statistics.mjs
+
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VIGIEAU_MIN_ZONE_COUNT: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Public application and Tarbes
+        run: node scripts/smoke-public.mjs
+      - name: Public map rendering and real PMTiles ranges
+        run: node scripts/smoke-browser.mjs
+      - name: Admin API, clock and external publications
+        run: node scripts/smoke-admin.mjs
+      - name: data.gouv.fr resources
+        run: node scripts/smoke-datagouv.mjs

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -37,6 +37,7 @@ jobs:
     timeout-minutes: 20
     env:
       VIGIEAU_MIN_ZONE_COUNT: 1
+      VIGIEAU_EXPECT_ZONE_PUBLICATION_MODE: legacy
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,6 +49,8 @@ jobs:
         run: node scripts/smoke-public.mjs
       - name: Public map rendering and real PMTiles ranges
         run: node scripts/smoke-browser.mjs
+      - name: Verify admin smoke zone publication policy
+        run: node --test scripts/smoke-admin.test.mjs
       - name: Admin API, clock and external publications
         run: node scripts/smoke-admin.mjs
       - name: data.gouv.fr resources


### PR DESCRIPTION
Ajoute sur la branche par défaut le workflow planifié de supervision de la production. GitHub charge les workflows planifiés depuis `master`; les deux jobs extraient explicitement `develop`, qui contient les scripts de smoke test testés et déployés.

Portage strict de `.github/workflows/production-smoke.yml` depuis `8d31af0fe44910a75e9727787b98095668bb5321`. Aucun autre fichier n’est modifié.

Validation :
- CI du commit source : succès (`31793253637`)
- blob du workflow identique au commit source
- `prettier@3.9.6 --check` : succès
- `git diff --check` : succès