### PR TITLE
ci: configure production zone freshness policy

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -38,6 +38,8 @@ jobs:
     env:
       VIGIEAU_MIN_ZONE_COUNT: 1
       VIGIEAU_EXPECT_ZONE_PUBLICATION_MODE: legacy
+      VIGIEAU_ZONE_PUBLICATION_DEADLINE: "06:00"
+      VIGIEAU_LEGACY_ARTIFACT_MAX_SKEW_MINUTES: "30"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Porte sur le workflow planifié de `master` les deux paramètres de fraîcheur validés sur `develop` :

- deadline métier des zones à 06:00 Europe/Paris ;
- tolérance maximale de 30 minutes entre le cache legacy et les artefacts stables.

Portage strict de `.github/workflows/production-smoke.yml` depuis `3a084796e473fecab7524d53d9b07ca95a160c78`. Aucun autre fichier n’est modifié.

Validation :
- CI source : succès (`31801557981`)
- blob du workflow identique au commit source
- Prettier et `git diff --check` : succès