### PR TITLE
docs: document master as canonical branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Node n’est pas dockerisé : les applications Node/Nuxt/Nest se lancent en loca
 
 ## Branche de travail
 
+`master` est la branche canonique pour les contributions, la CI et les déploiements.
+
 ```bash
 git switch master
 ```


### PR DESCRIPTION
## Résumé

- documente `master` comme branche canonique pour les contributions, la CI et les déploiements

## Pourquoi

Le dépôt utilise désormais une branche de travail unique. Cette précision évite de réintroduire des contributions ou des automatisations sur l'ancienne branche de développement.

## Validation

- branche créée depuis `master@0eebd5174a406c334549d850649198ee398c8ffd`
- diff limité à `README.md`
- `git diff --check origin/master..HEAD`

Cette PR sert également de contrôle CI sur une base `master` moderne.
