### PR TITLE
fix: repair legacy SANDRE schema drift

### DIFF
--- a/apps/backend-admin/src/migrations/1786392000000-SandreZoneSchemaPrerequisites.ts
+++ b/apps/backend-admin/src/migrations/1786392000000-SandreZoneSchemaPrerequisites.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SandreZoneSchemaPrerequisites1786392000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "zone_alerte"
+        ADD COLUMN IF NOT EXISTS "idSandre" integer,
+        ADD COLUMN IF NOT EXISTS "codeSandre" character varying(32),
+        ADD COLUMN IF NOT EXISTS "statutSandre" character varying(20),
+        ADD COLUMN IF NOT EXISTS "dateMajSandre" date,
+        ADD COLUMN IF NOT EXISTS "numeroVersionSandre" integer,
+        ADD COLUMN IF NOT EXISTS "codesAlternatifs" jsonb,
+        ADD COLUMN IF NOT EXISTS "sandrePayloadHash" character varying(64)
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_zone_alerte_code_sandre_unique"
+      ON "zone_alerte" ("codeSandre")
+      WHERE "codeSandre" IS NOT NULL
+    `);
+  }
+
+  public down(): Promise<void> {
+    // These columns may predate TypeORM migrations, so rollback must preserve them.
+    return Promise.resolve();
+  }
+}

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-durability.migration.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-durability.migration.spec.ts
@@ -1,4 +1,39 @@
 import { SandreZoneDurability1786395600000 } from '../migrations/1786395600000-SandreZoneDurability';
+import { SandreZoneSchemaPrerequisites1786392000000 } from '../migrations/1786392000000-SandreZoneSchemaPrerequisites';
+
+describe('SandreZoneSchemaPrerequisites1786392000000', () => {
+  it('restores every column read by durability without destructive SQL', async () => {
+    const statements: string[] = [];
+    const queryRunner = {
+      query: jest.fn(async (sql: string) => statements.push(sql)),
+    };
+
+    const migration = new SandreZoneSchemaPrerequisites1786392000000();
+    await migration.up(queryRunner as any);
+    await migration.down();
+
+    const sql = statements.join('\n');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "idSandre" integer');
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "codeSandre" character varying(32)',
+    );
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "statutSandre" character varying(20)',
+    );
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "dateMajSandre" date');
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "numeroVersionSandre" integer',
+    );
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "codesAlternatifs" jsonb');
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "sandrePayloadHash" character varying(64)',
+    );
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_zone_alerte_code_sandre_unique"',
+    );
+    expect(sql).not.toMatch(/\b(?:DROP|DELETE|TRUNCATE)\b/);
+  });
+});
 
 describe('SandreZoneDurability1786395600000', () => {
   it('adds controlled provenance and the audited Corsica basin mapping only', async () => {

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-durability.postgres.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-durability.postgres.spec.ts
@@ -1,4 +1,6 @@
 import { DataSource, QueryRunner } from 'typeorm';
+import { SandreZoneSync1785484800000 } from '../migrations/1785484800000-SandreZoneSync';
+import { SandreZoneSchemaPrerequisites1786392000000 } from '../migrations/1786392000000-SandreZoneSchemaPrerequisites';
 import { SandreZoneDurability1786395600000 } from '../migrations/1786395600000-SandreZoneDurability';
 import {
   acquireHistoricalRecomputeLock,
@@ -602,6 +604,164 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
       await contender.release();
       await runner.query(`DELETE FROM zone_alerte WHERE id = 5000`);
     }
+  });
+});
+
+describeWithPostgres('Sandre schema drift recovery on PostgreSQL', () => {
+  const schema = `sandre_schema_drift_${process.pid}_${Date.now()}`;
+  let bootstrapDataSource: DataSource;
+  let driftDataSource: DataSource;
+
+  beforeAll(async () => {
+    bootstrapDataSource = await new DataSource({
+      type: 'postgres',
+      url: postgresUrl,
+      entities: [],
+      synchronize: false,
+      logging: false,
+    }).initialize();
+    await bootstrapDataSource.query(`CREATE SCHEMA "${schema}"`);
+
+    driftDataSource = await new DataSource({
+      type: 'postgres',
+      url: postgresUrl,
+      entities: [],
+      migrations: [
+        SandreZoneSync1785484800000,
+        SandreZoneSchemaPrerequisites1786392000000,
+        SandreZoneDurability1786395600000,
+      ],
+      migrationsTransactionMode: 'each',
+      synchronize: false,
+      logging: false,
+      extra: { options: `-c search_path=${schema},public` },
+    }).initialize();
+  });
+
+  afterAll(async () => {
+    if (driftDataSource?.isInitialized) {
+      await driftDataSource.destroy();
+    }
+    if (bootstrapDataSource?.isInitialized) {
+      await bootstrapDataSource.query(
+        `DROP SCHEMA IF EXISTS "${schema}" CASCADE`,
+      );
+      await bootstrapDataSource.destroy();
+    }
+  });
+
+  it('repairs a skipped legacy schema before durability reads its columns', async () => {
+    await driftDataSource.query(`
+      CREATE TABLE "zone_alerte" (
+        "id" integer PRIMARY KEY,
+        "legacyValue" text NOT NULL
+      );
+      INSERT INTO "zone_alerte" ("id", "legacyValue")
+      VALUES (1, 'preserve-me');
+      CREATE TABLE "migrations" (
+        "id" SERIAL NOT NULL,
+        "timestamp" bigint NOT NULL,
+        "name" character varying NOT NULL,
+        CONSTRAINT "PK_sandre_drift_migrations" PRIMARY KEY ("id")
+      );
+      INSERT INTO "migrations" ("timestamp", "name")
+      VALUES (1785484800000, 'SandreZoneSync1785484800000');
+    `);
+
+    const applied = await driftDataSource.runMigrations({
+      transaction: 'each',
+    });
+
+    expect(applied.map(({ name }) => name)).toEqual([
+      'SandreZoneSchemaPrerequisites1786392000000',
+      'SandreZoneDurability1786395600000',
+    ]);
+    const columns = await driftDataSource.query(`
+      SELECT
+        "column_name" AS "columnName",
+        "data_type" AS "dataType",
+        "character_maximum_length"::integer AS "maximumLength",
+        "is_nullable" AS "isNullable"
+      FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = 'zone_alerte'
+        AND "column_name" IN (
+          'idSandre',
+          'codeSandre',
+          'statutSandre',
+          'dateMajSandre',
+          'numeroVersionSandre',
+          'codesAlternatifs',
+          'sandrePayloadHash'
+        )
+      ORDER BY "column_name"
+    `);
+    expect(columns).toEqual([
+      {
+        columnName: 'codeSandre',
+        dataType: 'character varying',
+        maximumLength: 32,
+        isNullable: 'YES',
+      },
+      {
+        columnName: 'codesAlternatifs',
+        dataType: 'jsonb',
+        maximumLength: null,
+        isNullable: 'YES',
+      },
+      {
+        columnName: 'dateMajSandre',
+        dataType: 'date',
+        maximumLength: null,
+        isNullable: 'YES',
+      },
+      {
+        columnName: 'idSandre',
+        dataType: 'integer',
+        maximumLength: null,
+        isNullable: 'YES',
+      },
+      {
+        columnName: 'numeroVersionSandre',
+        dataType: 'integer',
+        maximumLength: null,
+        isNullable: 'YES',
+      },
+      {
+        columnName: 'sandrePayloadHash',
+        dataType: 'character varying',
+        maximumLength: 64,
+        isNullable: 'YES',
+      },
+      {
+        columnName: 'statutSandre',
+        dataType: 'character varying',
+        maximumLength: 20,
+        isNullable: 'YES',
+      },
+    ]);
+    await expect(
+      driftDataSource.query(`
+        SELECT "legacyValue", "sandreProvenance"
+        FROM "zone_alerte"
+        WHERE "id" = 1
+      `),
+    ).resolves.toEqual([
+      { legacyValue: 'preserve-me', sandreProvenance: 'legacy_unverified' },
+    ]);
+
+    const replayRunner = driftDataSource.createQueryRunner();
+    await replayRunner.connect();
+    try {
+      await expect(
+        new SandreZoneSchemaPrerequisites1786392000000().up(replayRunner),
+      ).resolves.toBeUndefined();
+    } finally {
+      await replayRunner.release();
+    }
+    await expect(
+      driftDataSource.runMigrations({ transaction: 'each' }),
+    ).resolves.toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Contexte

Le déploiement préproduction de la durabilité SANDRE a révélé une base où `SandreZoneSync1785484800000` était enregistrée comme appliquée alors que cinq colonnes étaient absentes. La migration suivante s’arrêtait donc avant toute modification partielle.

## Correction

- ajoute une migration additive et idempotente, ordonnée avant `SandreZoneDurability` ;
- restaure les sept prérequis SANDRE et l’index unique sans supprimer de données ;
- garde un `down` non destructif pour les colonnes héritées du bootstrap historique ;
- ajoute un test PostgreSQL reproduisant le drift réel et le replay.

## Validation

- backend-admin : 68 suites, 990 tests ;
- PostgreSQL ciblé : 6/6 ;
- migrations fresh : 21 migrations ;
- upgrade depuis `fc961fb` et schéma préprod exact : OK ;
- build, lint des fichiers modifiés, Prettier et diff-check : OK.