### PR TITLE
fix: repair historic statistic schema drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
         run: >-
           npm --prefix apps/backend test -- --runInBand
           src/data/statistic-cache-artifact.postgres.spec.ts
+          src/data/historic-config-schema-repair.postgres.spec.ts
         env:
           STATISTIC_CACHE_ARTIFACT_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/vigieau_ci
       - name: Verify statistic boundary recovery against PostgreSQL

--- a/apps/backend-admin/src/config/historic-config-schema-repair.migration.spec.ts
+++ b/apps/backend-admin/src/config/historic-config-schema-repair.migration.spec.ts
@@ -1,0 +1,123 @@
+import { HistoricConfigSchemaRepair1786831200000 } from '../migrations/1786831200000-HistoricConfigSchemaRepair';
+
+describe('HistoricConfigSchemaRepair1786831200000', () => {
+  it('repairs every historic config column behind the next checkpoint epoch', async () => {
+    const queries: Array<{ sql: string; parameters?: unknown[] }> = [];
+    const queryRunner = {
+      query: jest.fn(async (sql: string, parameters?: unknown[]) => {
+        queries.push({ sql, parameters });
+        if (sql.includes('AS "configHasNullHistoricComputeEpoch"')) {
+          return [
+            {
+              configHasNullHistoricComputeEpoch: true,
+              configIsEmpty: false,
+            },
+          ];
+        }
+        if (sql.includes('AS "checkpointEpochAvailable"')) {
+          return [{ checkpointEpochAvailable: true }];
+        }
+        if (sql.includes('AS "nextHistoricComputeEpoch"')) {
+          return [{ nextHistoricComputeEpoch: '2' }];
+        }
+        return [];
+      }),
+    };
+
+    await new HistoricConfigSchemaRepair1786831200000().up(queryRunner as any);
+
+    const sql = queries.map(({ sql: statement }) => statement).join('\n');
+    expect(sql).toContain('ALTER TABLE "config"');
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "computeMapGeneration" bigint NOT NULL DEFAULT 0',
+    );
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "computeStatsGeneration" bigint NOT NULL DEFAULT 0',
+    );
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "computeMapUpdatedAt" TIMESTAMP WITH TIME ZONE',
+    );
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "computeStatsUpdatedAt" TIMESTAMP WITH TIME ZONE',
+    );
+    expect(sql).toContain(
+      'ADD COLUMN IF NOT EXISTS "historicComputeEpoch" bigint',
+    );
+    expect(sql).toContain(
+      'LOCK TABLE "historic_department_checkpoint" IN SHARE MODE',
+    );
+    expect(sql).toContain('MAX("historicComputeEpoch")');
+    expect(sql).toContain('UPDATE "config"');
+    expect(sql).toContain('ALTER COLUMN "historicComputeEpoch" SET DEFAULT 0');
+    expect(sql).toContain('ALTER COLUMN "historicComputeEpoch" SET NOT NULL');
+    expect(sql).not.toContain('DROP COLUMN');
+    expect(
+      queries.find(({ sql: statement }) =>
+        statement.includes('UPDATE "config"'),
+      )?.parameters,
+    ).toEqual(['2']);
+  });
+
+  it('never rewrites an existing historic compute epoch', async () => {
+    const queries: string[] = [];
+    const queryRunner = {
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes('AS "configHasNullHistoricComputeEpoch"')) {
+          return [
+            {
+              configHasNullHistoricComputeEpoch: false,
+              configIsEmpty: false,
+            },
+          ];
+        }
+        return [];
+      }),
+    };
+
+    await new HistoricConfigSchemaRepair1786831200000().up(queryRunner as any);
+
+    const sql = queries.join('\n');
+    expect(sql).not.toContain('UPDATE "config"');
+    expect(sql).not.toContain('INSERT INTO "config"');
+    expect(sql).not.toContain('historic_department_checkpoint');
+  });
+
+  it('seeds an empty config singleton behind the checkpoint fence', async () => {
+    const queries: Array<{ sql: string; parameters?: unknown[] }> = [];
+    const queryRunner = {
+      query: jest.fn(async (sql: string, parameters?: unknown[]) => {
+        queries.push({ sql, parameters });
+        if (sql.includes('AS "configHasNullHistoricComputeEpoch"')) {
+          return [
+            {
+              configHasNullHistoricComputeEpoch: false,
+              configIsEmpty: true,
+            },
+          ];
+        }
+        if (sql.includes('AS "checkpointEpochAvailable"')) {
+          return [{ checkpointEpochAvailable: true }];
+        }
+        if (sql.includes('AS "nextHistoricComputeEpoch"')) {
+          return [{ nextHistoricComputeEpoch: '2' }];
+        }
+        return [];
+      }),
+    };
+
+    await new HistoricConfigSchemaRepair1786831200000().up(queryRunner as any);
+
+    const insert = queries.find(({ sql }) =>
+      sql.includes('INSERT INTO "config"'),
+    );
+    expect(insert?.sql).toContain('ON CONFLICT ("id") DO NOTHING');
+    expect(insert?.parameters).toEqual(['2']);
+  });
+
+  it('keeps columns owned by earlier migrations on rollback', async () => {
+    await expect(
+      new HistoricConfigSchemaRepair1786831200000().down(),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/backend-admin/src/migrations/1786831200000-HistoricConfigSchemaRepair.ts
+++ b/apps/backend-admin/src/migrations/1786831200000-HistoricConfigSchemaRepair.ts
@@ -1,0 +1,85 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class HistoricConfigSchemaRepair1786831200000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "config"
+        ADD COLUMN IF NOT EXISTS "computeMapGeneration" bigint NOT NULL DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS "computeStatsGeneration" bigint NOT NULL DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS "computeMapUpdatedAt" TIMESTAMP WITH TIME ZONE,
+        ADD COLUMN IF NOT EXISTS "computeStatsUpdatedAt" TIMESTAMP WITH TIME ZONE,
+        ADD COLUMN IF NOT EXISTS "historicComputeEpoch" bigint
+    `);
+
+    const [configState] = await queryRunner.query(`
+      SELECT
+        EXISTS (
+          SELECT 1
+          FROM "config"
+          WHERE "historicComputeEpoch" IS NULL
+        ) AS "configHasNullHistoricComputeEpoch",
+        NOT EXISTS (
+          SELECT 1
+          FROM "config"
+        ) AS "configIsEmpty"
+    `);
+    const configHasNullHistoricComputeEpoch =
+      configState?.configHasNullHistoricComputeEpoch === true;
+    const configIsEmpty = configState?.configIsEmpty === true;
+
+    if (configHasNullHistoricComputeEpoch || configIsEmpty) {
+      const [checkpointState] = await queryRunner.query(`
+        SELECT EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_schema = current_schema()
+            AND table_name = 'historic_department_checkpoint'
+            AND column_name = 'historicComputeEpoch'
+        ) AS "checkpointEpochAvailable"
+      `);
+      let nextHistoricComputeEpoch = '0';
+      if (checkpointState?.checkpointEpochAvailable === true) {
+        await queryRunner.query(
+          'LOCK TABLE "historic_department_checkpoint" IN SHARE MODE',
+        );
+        const [checkpointFence] = await queryRunner.query(`
+          SELECT (
+            COALESCE(MAX("historicComputeEpoch"), -1) + 1
+          )::text AS "nextHistoricComputeEpoch"
+          FROM "historic_department_checkpoint"
+        `);
+        nextHistoricComputeEpoch =
+          checkpointFence?.nextHistoricComputeEpoch ?? '0';
+      }
+      if (configIsEmpty) {
+        await queryRunner.query(
+          `
+            INSERT INTO "config" ("id", "historicComputeEpoch")
+            VALUES (1, $1::bigint)
+            ON CONFLICT ("id") DO NOTHING
+          `,
+          [nextHistoricComputeEpoch],
+        );
+      }
+      await queryRunner.query(
+        `
+          UPDATE "config"
+          SET "historicComputeEpoch" = $1::bigint
+          WHERE "historicComputeEpoch" IS NULL
+        `,
+        [nextHistoricComputeEpoch],
+      );
+    }
+
+    await queryRunner.query(`
+      ALTER TABLE "config"
+        ALTER COLUMN "historicComputeEpoch" SET DEFAULT 0,
+        ALTER COLUMN "historicComputeEpoch" SET NOT NULL
+    `);
+  }
+
+  public down(): Promise<void> {
+    // These columns belong to earlier migrations and must survive this repair rollback.
+    return Promise.resolve();
+  }
+}

--- a/apps/backend/src/data/historic-config-schema-repair.postgres.spec.ts
+++ b/apps/backend/src/data/historic-config-schema-repair.postgres.spec.ts
@@ -1,0 +1,344 @@
+import { DataSource } from 'typeorm';
+import { Config } from '@shared/entities/config.entity';
+import { HistoricCursorGeneration1786032000000 } from '../../../backend-admin/src/migrations/1786032000000-HistoricCursorGeneration';
+import { HistoricCursorProgress1786132800000 } from '../../../backend-admin/src/migrations/1786132800000-HistoricCursorProgress';
+import { HistoricDepartmentCheckpoint1786219200000 } from '../../../backend-admin/src/migrations/1786219200000-HistoricDepartmentCheckpoint';
+import { StatisticCachePublication1786744800000 } from '../../../backend-admin/src/migrations/1786744800000-StatisticCachePublication';
+import { HistoricConfigSchemaRepair1786831200000 } from '../../../backend-admin/src/migrations/1786831200000-HistoricConfigSchemaRepair';
+import { DataService } from './data.service';
+import { StatisticCacheArtifactService } from './statistic-cache-artifact.service';
+
+const postgresUrl = process.env.STATISTIC_CACHE_ARTIFACT_POSTGRES_URL;
+const describeWithPostgres = postgresUrl ? describe : describe.skip;
+
+describeWithPostgres(
+  'Historic config schema drift recovery on PostgreSQL',
+  () => {
+    const schemaName = `historic_config_repair_${process.pid}_${Date.now()}`;
+    let bootstrapDataSource: DataSource;
+    let dataSource: DataSource;
+
+    const dataSourceOptions = {
+      type: 'postgres' as const,
+      url: postgresUrl,
+      synchronize: false,
+      logging: false,
+      extra: { options: `-c search_path=${schemaName},public` },
+    };
+
+    beforeAll(async () => {
+      bootstrapDataSource = await new DataSource({
+        type: 'postgres',
+        url: postgresUrl,
+        synchronize: false,
+        logging: false,
+      }).initialize();
+      await bootstrapDataSource.query(`CREATE SCHEMA "${schemaName}"`);
+    });
+
+    afterAll(async () => {
+      if (dataSource?.isInitialized) {
+        await dataSource.destroy();
+      }
+      if (bootstrapDataSource?.isInitialized) {
+        await bootstrapDataSource.query(
+          `DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`,
+        );
+        await bootstrapDataSource.destroy();
+      }
+    });
+
+    it('repairs an applied migration ledger before artifact and runtime reads', async () => {
+      const historicMigrations = [
+        HistoricCursorGeneration1786032000000,
+        HistoricCursorProgress1786132800000,
+        HistoricDepartmentCheckpoint1786219200000,
+        StatisticCachePublication1786744800000,
+      ];
+      const legacyDataSource = await new DataSource({
+        ...dataSourceOptions,
+        entities: [],
+        migrations: historicMigrations,
+        migrationsTransactionMode: 'each',
+      }).initialize();
+      await legacyDataSource.query(`
+      CREATE TABLE "departement" (
+        "id" SERIAL PRIMARY KEY
+      );
+      INSERT INTO "departement" ("id") VALUES (1);
+      CREATE TABLE "config" (
+        "id" integer PRIMARY KEY DEFAULT 1,
+        "computeMapDate" date,
+        "computeStatsDate" date,
+        "computeZoneAlerteComputedDate" timestamp
+      );
+      INSERT INTO "config" (
+        "id", "computeMapDate", "computeStatsDate",
+        "computeZoneAlerteComputedDate"
+      ) VALUES (
+        1, DATE '2011-11-14', DATE '2011-11-14',
+        TIMESTAMP '2026-08-05 14:28:10.881'
+      );
+      CREATE TABLE "zone_publication_instance" (
+        "instanceId" character varying(200) PRIMARY KEY,
+        "heartbeatAt" timestamp with time zone NOT NULL DEFAULT now()
+      );
+      CREATE TABLE "zone_publication_state" (
+        "id" integer PRIMARY KEY,
+        "activePublicationId" uuid
+      );
+      INSERT INTO "zone_publication_state" VALUES (1, NULL);
+      CREATE TABLE "zone_publication_source_state" (
+        "id" integer PRIMARY KEY,
+        "revision" bigint NOT NULL DEFAULT 0
+      );
+      INSERT INTO "zone_publication_source_state" VALUES (1, 42);
+      CREATE TABLE "statistic_publication_state" (
+        "id" integer PRIMARY KEY,
+        "revision" bigint NOT NULL DEFAULT 0,
+        "currentPublishedDate" date,
+        "historicPublishedThrough" date,
+        "historicDirtyFrom" date,
+        "historicDirtyThrough" date
+      );
+      INSERT INTO "statistic_publication_state" VALUES (
+        1, 9, DATE '2026-08-14', DATE '2011-11-13',
+        DATE '2011-11-14', DATE '2026-08-13'
+      );
+      CREATE TABLE "current_zone_recompute_request" (
+        "departementId" integer PRIMARY KEY
+      );
+      CREATE TABLE "statistic_commune_snapshot" (
+        "snapshotDate" date NOT NULL,
+        "scope" character varying(500) NOT NULL,
+        "status" character varying(20) NOT NULL,
+        "expectedCommuneCount" integer NOT NULL,
+        "processedCommuneCount" integer NOT NULL DEFAULT 0,
+        "sourceRevision" bigint,
+        PRIMARY KEY ("snapshotDate", "scope")
+      );
+    `);
+
+      const historicApplied = await legacyDataSource.runMigrations({
+        transaction: 'each',
+      });
+      expect(historicApplied.map(({ name }) => name)).toEqual([
+        'HistoricCursorGeneration1786032000000',
+        'HistoricCursorProgress1786132800000',
+        'HistoricDepartmentCheckpoint1786219200000',
+        'StatisticCachePublication1786744800000',
+      ]);
+      await legacyDataSource.query(`
+      INSERT INTO "historic_department_checkpoint" (
+        "computedFor", "departementId", "historicComputeEpoch",
+        "sourceRevision", "materializationVersion", "inputSignature",
+        "outputSignature", "zoneCount"
+      ) VALUES
+        (
+          DATE '2026-08-12', 1, 0, '16', 'historic-v1',
+          repeat('a', 64), repeat('b', 64), 1
+        ),
+        (
+          DATE '2026-08-13', 1, 1, '441', 'historic-v1',
+          repeat('c', 64), repeat('d', 64), 1
+        )
+    `);
+      await legacyDataSource.query(`
+      ALTER TABLE "config"
+        DROP COLUMN "computeMapGeneration",
+        DROP COLUMN "computeStatsGeneration",
+        DROP COLUMN "computeMapUpdatedAt",
+        DROP COLUMN "computeStatsUpdatedAt",
+        DROP COLUMN "historicComputeEpoch"
+    `);
+      await legacyDataSource.destroy();
+
+      dataSource = await new DataSource({
+        ...dataSourceOptions,
+        entities: [Config],
+        migrations: [
+          ...historicMigrations,
+          HistoricConfigSchemaRepair1786831200000,
+        ],
+        migrationsTransactionMode: 'each',
+      }).initialize();
+      const artifactService = new StatisticCacheArtifactService(dataSource);
+      const runtimeService = new DataService(
+        undefined as any,
+        undefined as any,
+        undefined as any,
+        undefined as any,
+        undefined as any,
+        dataSource,
+        artifactService,
+      );
+
+      await expect(
+        dataSource.getRepository(Config).findOneBy({ id: 1 }),
+      ).rejects.toThrow(/computeMapGeneration/);
+      await expect(
+        (runtimeService as any).readPublicationState(dataSource),
+      ).rejects.toThrow(/historicComputeEpoch/);
+
+      const repaired = await dataSource.runMigrations({ transaction: 'each' });
+      expect(repaired.map(({ name }) => name)).toEqual([
+        'HistoricConfigSchemaRepair1786831200000',
+      ]);
+
+      const columns = await dataSource.query(`
+      SELECT
+        "column_name" AS "columnName",
+        "data_type" AS "dataType",
+        "is_nullable" AS "isNullable",
+        "column_default" AS "columnDefault"
+      FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = 'config'
+        AND "column_name" IN (
+          'computeMapGeneration',
+          'computeStatsGeneration',
+          'computeMapUpdatedAt',
+          'computeStatsUpdatedAt',
+          'historicComputeEpoch'
+        )
+      ORDER BY "column_name"
+    `);
+      expect(columns).toEqual([
+        {
+          columnName: 'computeMapGeneration',
+          dataType: 'bigint',
+          isNullable: 'NO',
+          columnDefault: '0',
+        },
+        {
+          columnName: 'computeMapUpdatedAt',
+          dataType: 'timestamp with time zone',
+          isNullable: 'YES',
+          columnDefault: null,
+        },
+        {
+          columnName: 'computeStatsGeneration',
+          dataType: 'bigint',
+          isNullable: 'NO',
+          columnDefault: '0',
+        },
+        {
+          columnName: 'computeStatsUpdatedAt',
+          dataType: 'timestamp with time zone',
+          isNullable: 'YES',
+          columnDefault: null,
+        },
+        {
+          columnName: 'historicComputeEpoch',
+          dataType: 'bigint',
+          isNullable: 'NO',
+          columnDefault: '0',
+        },
+      ]);
+      await expect(
+        dataSource.getRepository(Config).findOneByOrFail({ id: 1 }),
+      ).resolves.toMatchObject({
+        computeMapDate: '2011-11-14',
+        computeStatsDate: '2011-11-14',
+        computeMapGeneration: '0',
+        computeStatsGeneration: '0',
+        computeMapUpdatedAt: null,
+        computeStatsUpdatedAt: null,
+        historicComputeEpoch: '2',
+      });
+      await expect(
+        (runtimeService as any).readPublicationState(dataSource),
+      ).resolves.toMatchObject({
+        revision: '9',
+        statisticCachePublicationId: null,
+        currentPublishedDate: '2026-08-14',
+        historicMapCursor: '2011-11-14',
+        historicStatsCursor: '2011-11-14',
+        sourceRevision: '42',
+        historicComputeEpoch: '2',
+      });
+      await expect(artifactService.loadActive()).resolves.toBeNull();
+
+      const runRepair = async () => {
+        const runner = dataSource.createQueryRunner();
+        await runner.connect();
+        await runner.startTransaction();
+        try {
+          await new HistoricConfigSchemaRepair1786831200000().up(runner);
+          await runner.commitTransaction();
+        } catch (error) {
+          await runner.rollbackTransaction();
+          throw error;
+        } finally {
+          await runner.release();
+        }
+      };
+
+      await runRepair();
+      const [replayed] = await dataSource.query(`
+          SELECT "historicComputeEpoch"::text AS "historicComputeEpoch"
+          FROM "config"
+          WHERE "id" = 1
+      `);
+      expect(replayed.historicComputeEpoch).toBe('2');
+      await dataSource.query(`
+          UPDATE "config"
+          SET "historicComputeEpoch" = 41
+          WHERE "id" = 1
+      `);
+      await runRepair();
+      await expect(
+        dataSource.getRepository(Config).findOneByOrFail({ id: 1 }),
+      ).resolves.toMatchObject({
+        computeMapGeneration: '0',
+        computeStatsGeneration: '0',
+        historicComputeEpoch: '41',
+      });
+
+      await dataSource.query(`
+        ALTER TABLE "config"
+          ALTER COLUMN "historicComputeEpoch" DROP NOT NULL,
+          ALTER COLUMN "historicComputeEpoch" DROP DEFAULT;
+        UPDATE "config"
+        SET "historicComputeEpoch" = NULL
+        WHERE "id" = 1
+      `);
+      await runRepair();
+      await expect(
+        dataSource.getRepository(Config).findOneByOrFail({ id: 1 }),
+      ).resolves.toMatchObject({ historicComputeEpoch: '2' });
+      const [partialRepairColumn] = await dataSource.query(`
+        SELECT
+          "is_nullable" AS "isNullable",
+          "column_default" AS "columnDefault"
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'config'
+          AND column_name = 'historicComputeEpoch'
+      `);
+      expect(partialRepairColumn).toEqual({
+        isNullable: 'NO',
+        columnDefault: '0',
+      });
+
+      await dataSource.query('DELETE FROM "config"');
+      await runRepair();
+      await expect(
+        dataSource.getRepository(Config).findOneByOrFail({ id: 1 }),
+      ).resolves.toMatchObject({
+        id: 1,
+        computeMapGeneration: '0',
+        computeStatsGeneration: '0',
+        historicComputeEpoch: '2',
+      });
+      await expect(
+        (runtimeService as any).readPublicationState(dataSource),
+      ).resolves.toMatchObject({
+        historicMapCursor: null,
+        historicStatsCursor: null,
+        historicComputeEpoch: '2',
+      });
+      await new HistoricConfigSchemaRepair1786831200000().down();
+    }, 60_000);
+  },
+);


### PR DESCRIPTION
## Contexte

Le warm-up de l’API préproduction a révélé cinq colonnes `config` supprimées physiquement alors que leurs migrations historiques étaient enregistrées. Cela rendait les endpoints de statistiques et le health de publication indisponibles.

## Correction

- restaure les cinq champs de curseur/génération historiques de façon additive ;
- restaure `historicComputeEpoch` derrière un nouveau fence calculé sous verrou depuis les checkpoints persistés ;
- couvre aussi une colonne partielle nullable et une table `config` vide ;
- ne modifie jamais une epoch existante et garde un rollback non destructif ;
- ajoute le scénario PostgreSQL réel au job CI.

## Validation

- PostgreSQL: attisdropped, nullable, table vide, checkpoints absents/vides, replay, valeur existante et concurrence ;
- fresh 22 migrations et upgrade depuis `edc99a` avec cette seule migration ;
- builds backend/admin, tests runtime ciblés, lint, Prettier et diff-check : OK.