### PR TITLE
fix: preserve canonical restriction severity

### DIFF
--- a/apps/backend-admin/src/scripts/sandre-reconciliation-plans/2026-08-15-prod-sandre-unblock.json
+++ b/apps/backend-admin/src/scripts/sandre-reconciliation-plans/2026-08-15-prod-sandre-unblock.json
@@ -89,7 +89,15 @@
       "targetZoneId": 9704,
       "expectedSourceCode": "52_49_14",
       "expectedSandreGid": 408,
-      "officialCode": "300"
+      "officialCode": "300",
+      "restrictionConflictPolicy": {
+        "mode": "prefer_source",
+        "expectedCount": 23,
+        "expectedFingerprint": "c1e3bad0f1b327b861ec60c7153703680b0541fe0d268dd4596aba55b5f3ea56",
+        "allowedDifferingFields": ["niveauGravite"],
+        "requiredParentStatus": "abroge",
+        "requireSourceSeverityStrictlyHigher": true
+      }
     }
   ]
 }

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-durability.postgres.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-durability.postgres.spec.ts
@@ -223,6 +223,20 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
 
   it('applies and replays every reconciliation strategy without losing history', async () => {
     await seedReconciliationFixture(runner);
+    const canonicalRestrictionConflicts = [
+      {
+        arreteRestrictionId: 10,
+        parentStatus: 'abroge',
+        sourceRestrictionId: 101,
+        targetRestrictionId: 100,
+        sourceArreteCadreId: 3,
+        targetArreteCadreId: 3,
+        sourceNomGroupementAep: null,
+        targetNomGroupementAep: null,
+        sourceNiveauGravite: 'crise',
+        targetNiveauGravite: 'alerte',
+      },
+    ];
     const plan = parseSandreReconciliationPlan({
       schemaVersion: 1,
       operationId: 'postgres-all-strategies',
@@ -258,10 +272,70 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
           expectedSourceCode: '52_49_14',
           expectedSandreGid: 408,
           officialCode: '300',
+          restrictionConflictPolicy: {
+            mode: 'prefer_source',
+            expectedCount: canonicalRestrictionConflicts.length,
+            expectedFingerprint: fingerprint(canonicalRestrictionConflicts),
+            allowedDifferingFields: ['niveauGravite'],
+            requiredParentStatus: 'abroge',
+            requireSourceSeverityStrictlyHigher: true,
+          },
         },
       ],
     });
     const official = [officialErdreFeature()];
+    const [sourceOnlyBefore] = await runner.query(`
+      SELECT count(*)::integer AS count
+      FROM restriction source
+      WHERE source."zoneAlerteId" = 9707
+        AND NOT EXISTS (
+          SELECT 1
+          FROM restriction target
+          WHERE target."arreteRestrictionId" = source."arreteRestrictionId"
+            AND target."zoneAlerteId" = 9704
+        )
+    `);
+    expect(sourceOnlyBefore.count).toBe(1);
+
+    await runner.query(
+      `UPDATE restriction SET "nomGroupementAep" = 'drift' WHERE id = 101`,
+    );
+    await expect(
+      auditSandreReconciliationPlan(runner, plan, official),
+    ).rejects.toThrow('restriction fields differ');
+    await runner.query(
+      `UPDATE restriction SET "nomGroupementAep" = NULL WHERE id = 101`,
+    );
+
+    await runner.query(
+      `UPDATE arrete_restriction SET statut = 'publie' WHERE id = 10`,
+    );
+    await expect(
+      auditSandreReconciliationPlan(runner, plan, official),
+    ).rejects.toThrow('restriction parent status changed');
+    await runner.query(
+      `UPDATE arrete_restriction SET statut = 'abroge' WHERE id = 10`,
+    );
+
+    await runner.query(
+      `DELETE FROM restriction_commune WHERE "restrictionId" = 100 AND "communeId" = 2`,
+    );
+    await expect(
+      auditSandreReconciliationPlan(runner, plan, official),
+    ).rejects.toThrow('restriction communes differ');
+    await runner.query(
+      `INSERT INTO restriction_commune ("restrictionId", "communeId") VALUES (100, 2)`,
+    );
+
+    await runner.query(
+      `UPDATE restriction SET "niveauGravite" = 'vigilance' WHERE id = 100`,
+    );
+    await expect(
+      auditSandreReconciliationPlan(runner, plan, official),
+    ).rejects.toThrow('restriction conflicts changed');
+    await runner.query(
+      `UPDATE restriction SET "niveauGravite" = 'alerte' WHERE id = 100`,
+    );
 
     await runner.query(
       `UPDATE usage SET "descriptionCrise" = 'different' WHERE id = 2`,
@@ -278,6 +352,11 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
     expect(beforeState.restrictions).toHaveLength(3);
     const audits = await auditSandreReconciliationPlan(runner, plan, official);
     expect(audits.every((audit) => audit.status === 'ready')).toBe(true);
+    expect(audits[3].restrictionConflicts).toEqual({
+      policy: 'prefer_source',
+      count: 1,
+      fingerprint: fingerprint(canonicalRestrictionConflicts),
+    });
     expect(audits[3].geometry).toEqual(
       expect.objectContaining({
         officialCode: '300',
@@ -411,6 +490,16 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
       communes: 3,
       source_refs: 0,
     });
+    const canonicalRestrictions = await runner.query(`
+      SELECT id, "zoneAlerteId", "niveauGravite"
+      FROM restriction
+      WHERE id IN (100, 101, 102)
+      ORDER BY id
+    `);
+    expect(canonicalRestrictions).toEqual([
+      { id: 100, zoneAlerteId: 9704, niveauGravite: 'crise' },
+      { id: 102, zoneAlerteId: 9704, niveauGravite: 'crise' },
+    ]);
 
     await runner.startTransaction('SERIALIZABLE');
     try {
@@ -871,7 +960,7 @@ async function seedReconciliationFixture(runner: QueryRunner): Promise<void> {
       "nomGroupementAep", "niveauGravite"
     ) VALUES
       (100, 10, 9704, 3, NULL, 'alerte'),
-      (101, 10, 9707, 3, NULL, 'alerte'),
+      (101, 10, 9707, 3, NULL, 'crise'),
       (102, 11, 9707, 4, NULL, 'crise');
     INSERT INTO usage (
       id, nom, "thematiqueId", "restrictionId", "arreteCadreId",
@@ -882,6 +971,7 @@ async function seedReconciliationFixture(runner: QueryRunner): Promise<void> {
       (3, 'Unique', 1, 102, NULL, false, true, 'unique');
     INSERT INTO restriction_commune ("restrictionId", "communeId") VALUES
       (100, 1),
+      (100, 2),
       (101, 1),
       (101, 2),
       (102, 3);

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.spec.ts
@@ -1,11 +1,15 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import {
+  assertCanonicalDuplicateRestrictionConflicts,
   auditSandreSyncExpectations,
+  CanonicalDuplicateRestrictionConflict,
+  CanonicalizeDuplicateAction,
   parseSandreReconciliationPlan,
   reconciliationPlanFingerprint,
   SandreReconciliationPlan,
 } from './sandre-zone-reconciliation-actions';
+import { fingerprint } from './sandre-zone-reconciliation';
 
 describe('audited Sandre reconciliation plans', () => {
   const planPath = resolve(
@@ -52,9 +56,74 @@ describe('audited Sandre reconciliation plans', () => {
       ]),
     );
     expect(reconciliationPlanFingerprint(plan)).toMatch(/^[a-f0-9]{64}$/);
+    expect(plan.actions[5]).toEqual(
+      expect.objectContaining({
+        restrictionConflictPolicy: {
+          mode: 'prefer_source',
+          expectedCount: 23,
+          expectedFingerprint:
+            'c1e3bad0f1b327b861ec60c7153703680b0541fe0d268dd4596aba55b5f3ea56',
+          allowedDifferingFields: ['niveauGravite'],
+          requiredParentStatus: 'abroge',
+          requireSourceSeverityStrictlyHigher: true,
+        },
+      }),
+    );
     expect(serializedPlan).not.toMatch(
       /DATABASE_|API_SANDRE|PASSWORD|SECRET|postgres(?:ql)?:\/\//i,
     );
+  });
+
+  it('requires an exact restriction conflict policy for canonical duplicates', () => {
+    const conflict = canonicalConflict();
+    const action = canonicalAction([conflict]);
+
+    expect(
+      assertCanonicalDuplicateRestrictionConflicts(action, [conflict]),
+    ).toEqual({
+      policy: 'prefer_source',
+      count: 1,
+      fingerprint: fingerprint([conflict]),
+    });
+
+    expect(() =>
+      parseSandreReconciliationPlan({
+        schemaVersion: 1,
+        operationId: 'missing-conflict-policy',
+        description: 'test',
+        actions: [
+          {
+            strategy: 'canonicalize_duplicate',
+            departmentCode: '49',
+            zoneType: 'SOU',
+            sourceZoneId: 9707,
+            targetZoneId: 9704,
+            expectedSandreGid: 408,
+            officialCode: '300',
+          },
+        ],
+      }),
+    ).toThrow('Invalid canonical Sandre duplicate action');
+  });
+
+  it('fails closed when canonical restriction conflicts drift', () => {
+    const conflict = canonicalConflict();
+    const action = canonicalAction([conflict]);
+
+    expect(() =>
+      assertCanonicalDuplicateRestrictionConflicts(action, [
+        { ...conflict, targetRestrictionId: 999 },
+      ]),
+    ).toThrow('restriction conflicts changed');
+    expect(() =>
+      assertCanonicalDuplicateRestrictionConflicts(action, [
+        {
+          ...conflict,
+          sourceNiveauGravite: 'vigilance',
+          targetNiveauGravite: 'alerte',
+        },
+      ]),
+    ).toThrow('source severity is not stronger');
   });
 
   it('rejects duplicate sources and unknown metadata instead of silently dropping it', () => {
@@ -250,6 +319,51 @@ function expectationPlan(
       },
     ],
   });
+}
+
+function canonicalAction(
+  conflicts: CanonicalDuplicateRestrictionConflict[],
+): CanonicalizeDuplicateAction {
+  const plan = parseSandreReconciliationPlan({
+    schemaVersion: 1,
+    operationId: 'canonical-conflict-test',
+    description: 'test',
+    actions: [
+      {
+        strategy: 'canonicalize_duplicate',
+        departmentCode: '49',
+        zoneType: 'SOU',
+        sourceZoneId: 9707,
+        targetZoneId: 9704,
+        expectedSandreGid: 408,
+        officialCode: '300',
+        restrictionConflictPolicy: {
+          mode: 'prefer_source',
+          expectedCount: conflicts.length,
+          expectedFingerprint: fingerprint(conflicts),
+          allowedDifferingFields: ['niveauGravite'],
+          requiredParentStatus: 'abroge',
+          requireSourceSeverityStrictlyHigher: true,
+        },
+      },
+    ],
+  });
+  return plan.actions[0] as CanonicalizeDuplicateAction;
+}
+
+function canonicalConflict(): CanonicalDuplicateRestrictionConflict {
+  return {
+    arreteRestrictionId: 10,
+    parentStatus: 'abroge',
+    sourceRestrictionId: 101,
+    targetRestrictionId: 100,
+    sourceArreteCadreId: 3,
+    targetArreteCadreId: 3,
+    sourceNomGroupementAep: null,
+    targetNomGroupementAep: null,
+    sourceNiveauGravite: 'crise',
+    targetNiveauGravite: 'alerte',
+  };
 }
 
 function officialSnapshot(departmentCode: string, features: any[]): any {

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.ts
@@ -41,6 +41,14 @@ export interface CanonicalizeDuplicateAction extends SandreReconciliationActionB
   targetZoneId: number;
   expectedSandreGid: number;
   officialCode: string;
+  restrictionConflictPolicy: {
+    mode: 'prefer_source';
+    expectedCount: number;
+    expectedFingerprint: string;
+    allowedDifferingFields: ['niveauGravite'];
+    requiredParentStatus: 'abroge';
+    requireSourceSeverityStrictlyHigher: true;
+  };
 }
 
 export type SandreReconciliationAction =
@@ -136,6 +144,24 @@ export interface SandreActionAudit {
     customizations: number;
     aliases: number;
   };
+  restrictionConflicts: {
+    policy: 'prefer_source';
+    count: number;
+    fingerprint: string;
+  } | null;
+}
+
+export interface CanonicalDuplicateRestrictionConflict {
+  arreteRestrictionId: number;
+  parentStatus: string;
+  sourceRestrictionId: number;
+  targetRestrictionId: number;
+  sourceArreteCadreId: number | null;
+  targetArreteCadreId: number | null;
+  sourceNomGroupementAep: string | null;
+  targetNomGroupementAep: string | null;
+  sourceNiveauGravite: string;
+  targetNiveauGravite: string;
 }
 
 export interface SandreReconciliationQueryExecutor {
@@ -748,6 +774,7 @@ async function auditAction(
         departmentId: Number(source.departementId),
         geometry: null,
         operationalReferences: references,
+        restrictionConflicts: null,
       };
     }
     if (source.idSandre !== null || source.codeSandre !== null) {
@@ -761,9 +788,11 @@ async function auditAction(
       departmentId: Number(source.departementId),
       geometry: null,
       operationalReferences: references,
+      restrictionConflicts: null,
     };
   }
 
+  let restrictionConflicts: SandreActionAudit['restrictionConflicts'] = null;
   if (action.strategy === 'canonicalize_duplicate') {
     if (
       (!alreadyApplied &&
@@ -777,7 +806,12 @@ async function auditAction(
         `Duplicate canonicalization identity mismatch for ${action.sourceZoneId}`,
       );
     }
-    await assertCanonicalDuplicatePayloads(executor, action);
+    if (!alreadyApplied) {
+      restrictionConflicts = await assertCanonicalDuplicatePayloads(
+        executor,
+        action,
+      );
+    }
   } else {
     if (source.disabled !== true || targets.some((target) => target.disabled)) {
       throw new Error(
@@ -832,6 +866,7 @@ async function auditAction(
       departmentId: Number(source.departementId),
       geometry,
       operationalReferences: references,
+      restrictionConflicts: null,
     };
   }
 
@@ -841,6 +876,7 @@ async function auditAction(
     departmentId: Number(source.departementId),
     geometry,
     operationalReferences: references,
+    restrictionConflicts,
   };
 }
 
@@ -974,29 +1010,97 @@ async function loadActionGeometryEvidence(
 async function assertCanonicalDuplicatePayloads(
   executor: SandreReconciliationQueryExecutor,
   action: CanonicalizeDuplicateAction,
-): Promise<void> {
+): Promise<NonNullable<SandreActionAudit['restrictionConflicts']>> {
   const rows = await executor.query(
     `
-      SELECT source.id
+      SELECT
+        source."arreteRestrictionId" AS "arreteRestrictionId",
+        parent.statut AS "parentStatus",
+        source.id AS "sourceRestrictionId",
+        target.id AS "targetRestrictionId",
+        source."arreteCadreId" AS "sourceArreteCadreId",
+        target."arreteCadreId" AS "targetArreteCadreId",
+        source."nomGroupementAep" AS "sourceNomGroupementAep",
+        target."nomGroupementAep" AS "targetNomGroupementAep",
+        source."niveauGravite" AS "sourceNiveauGravite",
+        target."niveauGravite" AS "targetNiveauGravite",
+        ARRAY(
+          SELECT link."communeId"
+          FROM restriction_commune link
+          WHERE link."restrictionId" = source.id
+          ORDER BY link."communeId"
+        ) AS "sourceCommuneIds",
+        ARRAY(
+          SELECT link."communeId"
+          FROM restriction_commune link
+          WHERE link."restrictionId" = target.id
+          ORDER BY link."communeId"
+        ) AS "targetCommuneIds"
       FROM restriction source
       JOIN restriction target
         ON target."arreteRestrictionId" = source."arreteRestrictionId"
        AND target."zoneAlerteId" = $2
+      JOIN arrete_restriction parent
+        ON parent.id = source."arreteRestrictionId"
       WHERE source."zoneAlerteId" = $1
-        AND (
-          source."arreteCadreId" IS DISTINCT FROM target."arreteCadreId"
-          OR source."nomGroupementAep" IS DISTINCT FROM target."nomGroupementAep"
-          OR source."niveauGravite" IS DISTINCT FROM target."niveauGravite"
-        )
-      LIMIT 1
+      ORDER BY source."arreteRestrictionId", source.id, target.id
     `,
     [action.sourceZoneId, action.targetZoneId],
   );
-  if (rows.length > 0) {
+  if (
+    rows.some(
+      (row) =>
+        row.sourceArreteCadreId !== row.targetArreteCadreId ||
+        row.sourceNomGroupementAep !== row.targetNomGroupementAep,
+    )
+  ) {
     throw new Error(
-      `Canonical duplicate restrictions differ for zone ${action.sourceZoneId}`,
+      `Canonical duplicate restriction fields differ for zone ${action.sourceZoneId}`,
     );
   }
+  if (
+    rows.some(
+      (row) =>
+        row.parentStatus !==
+        action.restrictionConflictPolicy.requiredParentStatus,
+    )
+  ) {
+    throw new Error(
+      `Canonical duplicate restriction parent status changed for zone ${action.sourceZoneId}`,
+    );
+  }
+  if (
+    rows.some(
+      (row) =>
+        fingerprint(row.sourceCommuneIds) !== fingerprint(row.targetCommuneIds),
+    )
+  ) {
+    throw new Error(
+      `Canonical duplicate restriction communes differ for zone ${action.sourceZoneId}`,
+    );
+  }
+  const restrictionConflicts = rows
+    .filter((row) => row.sourceNiveauGravite !== row.targetNiveauGravite)
+    .map((row) => ({
+      arreteRestrictionId: Number(row.arreteRestrictionId),
+      parentStatus: String(row.parentStatus),
+      sourceRestrictionId: Number(row.sourceRestrictionId),
+      targetRestrictionId: Number(row.targetRestrictionId),
+      sourceArreteCadreId:
+        row.sourceArreteCadreId === null
+          ? null
+          : Number(row.sourceArreteCadreId),
+      targetArreteCadreId:
+        row.targetArreteCadreId === null
+          ? null
+          : Number(row.targetArreteCadreId),
+      sourceNomGroupementAep: row.sourceNomGroupementAep ?? null,
+      targetNomGroupementAep: row.targetNomGroupementAep ?? null,
+      sourceNiveauGravite: String(row.sourceNiveauGravite),
+      targetNiveauGravite: String(row.targetNiveauGravite),
+    }));
+  const restrictionConflictEvidence =
+    assertCanonicalDuplicateRestrictionConflicts(action, restrictionConflicts);
   const usageRows = await executor.query(
     `
       SELECT source.id
@@ -1026,6 +1130,45 @@ async function assertCanonicalDuplicatePayloads(
       `Canonical duplicate usages differ for zone ${action.sourceZoneId}`,
     );
   }
+  return restrictionConflictEvidence;
+}
+
+const RESTRICTION_SEVERITY_RANK: Record<string, number> = {
+  vigilance: 1,
+  alerte: 2,
+  alerte_renforcee: 3,
+  crise: 4,
+};
+
+export function assertCanonicalDuplicateRestrictionConflicts(
+  action: CanonicalizeDuplicateAction,
+  conflicts: CanonicalDuplicateRestrictionConflict[],
+): NonNullable<SandreActionAudit['restrictionConflicts']> {
+  for (const conflict of conflicts) {
+    const sourceRank = RESTRICTION_SEVERITY_RANK[conflict.sourceNiveauGravite];
+    const targetRank = RESTRICTION_SEVERITY_RANK[conflict.targetNiveauGravite];
+    if (!sourceRank || !targetRank || sourceRank <= targetRank) {
+      throw new Error(
+        `Canonical duplicate source severity is not stronger for restriction ${conflict.arreteRestrictionId}`,
+      );
+    }
+  }
+  const count = conflicts.length;
+  const conflictFingerprint = fingerprint(conflicts);
+  const expected = action.restrictionConflictPolicy;
+  if (
+    count !== expected.expectedCount ||
+    conflictFingerprint !== expected.expectedFingerprint
+  ) {
+    throw new Error(
+      `Canonical duplicate restriction conflicts changed for zone ${action.sourceZoneId}`,
+    );
+  }
+  return {
+    policy: expected.mode,
+    count,
+    fingerprint: conflictFingerprint,
+  };
 }
 
 async function preserveLocalZone(
@@ -1172,6 +1315,14 @@ async function canonicalizeDuplicate(
     `,
     parameters,
   );
+  await executor.query(`
+      UPDATE restriction target
+      SET "niveauGravite" = source."niveauGravite"
+      FROM sandre_duplicate_restriction duplicate
+      JOIN restriction source ON source.id = duplicate.source_id
+      WHERE target.id = duplicate.target_id
+        AND source."niveauGravite" IS DISTINCT FROM target."niveauGravite"
+  `);
   await executor.query(`
       INSERT INTO restriction_commune ("restrictionId", "communeId")
       SELECT duplicate.target_id, link."communeId"
@@ -1376,11 +1527,41 @@ function parseAction(value: unknown): SandreReconciliationAction {
     (!positiveInteger(action.expectedSandreGid) ||
       typeof action.officialCode !== 'string' ||
       action.officialCode.length === 0 ||
-      action.officialCode.length > 32)
+      action.officialCode.length > 32 ||
+      !isCanonicalRestrictionConflictPolicy(action.restrictionConflictPolicy))
   ) {
-    throw new Error('Invalid canonical Sandre gid');
+    throw new Error('Invalid canonical Sandre duplicate action');
+  }
+  if (
+    action.strategy !== 'canonicalize_duplicate' &&
+    action.restrictionConflictPolicy !== undefined
+  ) {
+    throw new Error(
+      'Restriction conflict resolution is only valid for canonical duplicates',
+    );
   }
   return action as unknown as SandreReconciliationAction;
+}
+
+function isCanonicalRestrictionConflictPolicy(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const policy = value as Record<string, unknown>;
+  return (
+    Object.keys(policy).sort().join(',') ===
+      'allowedDifferingFields,expectedCount,expectedFingerprint,mode,requireSourceSeverityStrictlyHigher,requiredParentStatus' &&
+    policy.mode === 'prefer_source' &&
+    Number.isInteger(policy.expectedCount) &&
+    Number(policy.expectedCount) >= 0 &&
+    typeof policy.expectedFingerprint === 'string' &&
+    /^[a-f0-9]{64}$/.test(policy.expectedFingerprint) &&
+    Array.isArray(policy.allowedDifferingFields) &&
+    policy.allowedDifferingFields.length === 1 &&
+    policy.allowedDifferingFields[0] === 'niveauGravite' &&
+    policy.requiredParentStatus === 'abroge' &&
+    policy.requireSourceSeverityStrictlyHigher === true
+  );
 }
 
 function positiveInteger(value: unknown): value is number {


### PR DESCRIPTION
## What changed

- seal the 23 production restriction conflicts in the audited SANDRE plan
- require historical parents, identical business payloads/communes/usages, and a strictly stronger source severity
- copy the approved source severity before canonical duplicate removal
- cover drift, source-only restrictions, replay, and PostgreSQL application

## Root cause

The production dry-run correctly rejected canonicalization because 23 historical restriction pairs differed in severity. The previous merge path would have retained the weaker canonical payload and lost the stronger legacy severity.

## Validation

- backend-admin build
- full backend-admin test suite: 70 suites / 1002 tests
- SANDRE PostgreSQL integration: 6/6
- targeted ESLint
- git diff --check

No production apply is permitted until a new signed dry-run succeeds on the deployed merge SHA.