### PR TITLE
fix: persist Sandre audit boundaries

### DIFF
--- a/apps/backend-admin/src/scripts/reconcile-sandre-zones.spec.ts
+++ b/apps/backend-admin/src/scripts/reconcile-sandre-zones.spec.ts
@@ -1,8 +1,13 @@
+import * as fsPromises from 'fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import {
   acquireSandreGlobalLock,
   acquireHistoricalRecomputeLock,
   assertNoOldReferences,
   currentTargetFingerprint,
+  earliestOperationRestrictionDate,
   fetchText,
   loadDatabaseState,
   loadReferenceCounts,
@@ -15,6 +20,7 @@ import {
   rollbackAndReleaseQueryRunner,
   releaseSandreGlobalLock,
   verifySandrePostSafeConvergence,
+  writeReportFile,
 } from './reconcile-sandre-zones';
 import { fingerprint } from '../zone_alerte/sandre-zone-reconciliation';
 
@@ -30,6 +36,25 @@ describe('reconcile-sandre-zones CLI safeguards', () => {
       SCALINGO_APP: 'regleau-back-preprod',
       NODE_ENV: 'preprod',
     };
+  });
+
+  it('keeps the earliest civil date when pg returns Date objects', () => {
+    const postgresDate = (year: number, month: number, day: number) =>
+      new Date(year, month - 1, day);
+
+    expect(
+      earliestOperationRestrictionDate({
+        restrictions: [
+          {
+            arreteRestrictionDateDebut: postgresDate(2022, 9, 30),
+          },
+          {
+            arreteRestrictionDateDebut: postgresDate(2016, 7, 18),
+          },
+          { arreteRestrictionDateDebut: null },
+        ],
+      } as any),
+    ).toBe('2016-07-18');
   });
 
   afterAll(() => {
@@ -103,6 +128,78 @@ describe('reconcile-sandre-zones CLI safeguards', () => {
         '/tmp/approved.json',
       ]),
     ).toThrow('--apply and --dry-run are mutually exclusive');
+  });
+
+  describe('report file persistence', () => {
+    let directory: string;
+
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'vigieau-sandre-report-'));
+    });
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+      await rm(directory, { force: true, recursive: true });
+    });
+
+    it('writes the exact content, syncs it and closes the file handle', async () => {
+      const reportPath = join(directory, 'approved.json');
+      const content = '{\n  "status": "approved"\n}\n';
+      const realOpen = fsPromises.open;
+      let syncSpy: jest.SpyInstance<Promise<void>, []>;
+      let closeSpy: jest.SpyInstance<Promise<void>, []>;
+
+      jest
+        .spyOn(fsPromises, 'open')
+        .mockImplementation(async (path, flags, mode) => {
+          const handle = await realOpen(path, flags, mode);
+          syncSpy = jest.spyOn(handle, 'sync');
+          closeSpy = jest.spyOn(handle, 'close');
+          return handle;
+        });
+
+      await writeReportFile(reportPath, content);
+
+      await expect(readFile(reportPath, 'utf8')).resolves.toBe(content);
+      expect(syncSpy).toHaveBeenCalledTimes(1);
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      expect(syncSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        closeSpy.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('preserves exclusive creation and never overwrites an existing report', async () => {
+      const reportPath = join(directory, 'approved.json');
+      await writeFile(reportPath, 'already approved', 'utf8');
+
+      await expect(
+        writeReportFile(reportPath, 'replacement'),
+      ).rejects.toMatchObject({ code: 'EEXIST' });
+      await expect(readFile(reportPath, 'utf8')).resolves.toBe(
+        'already approved',
+      );
+    });
+
+    it('preserves a write error when closing the file also fails', async () => {
+      const writeError = new Error('write failed');
+      const closeError = new Error('close failed');
+      jest.spyOn(fsPromises, 'open').mockResolvedValue({
+        writeFile: jest.fn().mockRejectedValue(writeError),
+        sync: jest.fn(),
+        close: jest.fn().mockRejectedValue(closeError),
+      } as any);
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      await expect(
+        writeReportFile(join(directory, 'approved.json'), 'content'),
+      ).rejects.toBe(writeError);
+      expect(consoleError).toHaveBeenCalledWith(
+        '[sandre-reconcile] report file cleanup failed',
+        closeError,
+      );
+    });
   });
 
   it('parses an audited operation plan only in dry-run mode', () => {
@@ -430,6 +527,9 @@ describe('reconcile-sandre-zones CLI safeguards', () => {
     expect(
       statements.join('\n').match(/statut IN \('a_venir', 'publie'\)/g),
     ).toHaveLength(3);
+    expect(statements.join('\n')).toContain(
+      'ar."dateDebut"::text AS "arreteRestrictionDateDebut"',
+    );
     const communeQuery = firstExecutor.query.mock.calls.find(([sql]) =>
       sql.includes('FROM ac_za_communes'),
     );

--- a/apps/backend-admin/src/scripts/reconcile-sandre-zones.ts
+++ b/apps/backend-admin/src/scripts/reconcile-sandre-zones.ts
@@ -2,8 +2,6 @@ import 'reflect-metadata';
 import 'dotenv/config';
 import { open, readFile } from 'fs/promises';
 import { resolve } from 'path';
-import { Readable } from 'stream';
-import { pipeline } from 'stream/promises';
 import { DataSource, QueryRunner } from 'typeorm';
 import {
   fetchSandreZoneSnapshot,
@@ -1191,15 +1189,29 @@ async function readOperationReportIfPresent(
   return { ...report, plan };
 }
 
-function earliestOperationRestrictionDate(
+export function earliestOperationRestrictionDate(
   state: Awaited<ReturnType<typeof loadSandreReconciliationState>>,
 ): string | null {
   return (
     state.restrictions
       .map((restriction) => restriction.arreteRestrictionDateDebut)
-      .filter((date): date is string => typeof date === 'string')
+      .map(normalizePostgresCivilDate)
+      .filter((date): date is string => date !== null)
       .sort()[0] ?? null
   );
+}
+
+function normalizePostgresCivilDate(value: unknown): string | null {
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    return null;
+  }
+  const year = String(value.getFullYear()).padStart(4, '0');
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 export function operationBusinessReferencesFingerprint(
@@ -2054,7 +2066,7 @@ export async function loadDatabaseState(
             restriction_row.id,
             restriction_row."arreteRestrictionId",
             ar.statut AS "arreteRestrictionStatut",
-            ar."dateDebut" AS "arreteRestrictionDateDebut",
+            ar."dateDebut"::text AS "arreteRestrictionDateDebut",
             restriction_row."zoneAlerteId",
             restriction_row."arreteCadreId",
             restriction_row."nomGroupementAep",
@@ -2309,16 +2321,30 @@ async function recordReconciliationDecisions(
   }
 }
 
-async function writeReportFile(path: string, content: string): Promise<void> {
+export async function writeReportFile(
+  path: string,
+  content: string,
+): Promise<void> {
   const handle = await open(path, 'wx');
+  let writeError: unknown;
   try {
-    await pipeline(
-      Readable.from([content]),
-      handle.createWriteStream({ autoClose: false }),
-    );
+    await handle.writeFile(content, 'utf8');
     await handle.sync();
+  } catch (error) {
+    writeError = error;
+    throw error;
   } finally {
-    await handle.close();
+    try {
+      await handle.close();
+    } catch (closeError) {
+      if (!writeError) {
+        throw closeError;
+      }
+      console.error(
+        '[sandre-reconcile] report file cleanup failed',
+        closeError,
+      );
+    }
   }
 }
 

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-durability.postgres.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-durability.postgres.spec.ts
@@ -5,6 +5,7 @@ import { SandreZoneDurability1786395600000 } from '../migrations/1786395600000-S
 import {
   acquireHistoricalRecomputeLock,
   clearSandreOperationRecomputeDebt,
+  earliestOperationRestrictionDate,
   operationBusinessReferencesFingerprint,
   prepareSandreOperationRecomputeDebt,
 } from '../scripts/reconcile-sandre-zones';
@@ -350,6 +351,12 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
     const beforeState = await loadSandreReconciliationState(runner, plan);
     const beforeFingerprint = fingerprint(beforeState);
     expect(beforeState.restrictions).toHaveLength(3);
+    expect(
+      beforeState.restrictions.map(
+        (restriction) => restriction.arreteRestrictionDateDebut,
+      ),
+    ).toEqual(['2016-07-18', '2016-07-18', '2021-01-01']);
+    expect(earliestOperationRestrictionDate(beforeState)).toBe('2016-07-18');
     const audits = await auditSandreReconciliationPlan(runner, plan, official);
     expect(audits.every((audit) => audit.status === 'ready')).toBe(true);
     expect(audits[3].restrictionConflicts).toEqual({
@@ -534,20 +541,31 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
     }
   }, 30_000);
 
-  it('resumes an existing recompute debt without rewinding or incrementing it', async () => {
+  it('persists the historical cursors and resumes an existing recompute debt', async () => {
     const firstDebt = await prepareSandreOperationRecomputeDebt(
       runner,
       'APPLIED',
       [1],
-      '2026-01-01',
+      '2016-07-18',
     );
     expect(firstDebt).toEqual([{ departmentId: 1, revision: 1 }]);
+    const [initialCursors] = await runner.query(`
+      SELECT
+        "computeMapDate"::text AS "computeMapDate",
+        "computeStatsDate"::text AS "computeStatsDate"
+      FROM config
+      WHERE id = 1
+    `);
+    expect(initialCursors).toEqual({
+      computeMapDate: '2016-07-18',
+      computeStatsDate: '2016-07-18',
+    });
 
     const crashResumeDebt = await prepareSandreOperationRecomputeDebt(
       runner,
       'ALREADY_APPLIED',
       [1],
-      '2026-01-01',
+      '2016-07-18',
     );
     expect(crashResumeDebt).toEqual(firstDebt);
     const [pendingState] = await runner.query(`
@@ -572,7 +590,7 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
       runner,
       'ALREADY_APPLIED',
       [1],
-      '2026-01-01',
+      '2016-07-18',
     );
     expect(cleanReplayDebt).toEqual([]);
     const [finalState] = await runner.query(`
@@ -953,7 +971,7 @@ async function seedReconciliationFixture(runner: QueryRunner): Promise<void> {
       (3, 9707),
       (4, 9707);
     INSERT INTO arrete_restriction (id, statut, "dateDebut") VALUES
-      (10, 'abroge', DATE '2020-01-01'),
+      (10, 'abroge', DATE '2016-07-18'),
       (11, 'abroge', DATE '2021-01-01');
     INSERT INTO restriction (
       id, "arreteRestrictionId", "zoneAlerteId", "arreteCadreId",

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.ts
@@ -491,7 +491,7 @@ export async function loadSandreReconciliationState(
       SELECT
         restriction.id,
         restriction."arreteRestrictionId",
-        parent."dateDebut" AS "arreteRestrictionDateDebut",
+        parent."dateDebut"::text AS "arreteRestrictionDateDebut",
         restriction."zoneAlerteId",
         restriction."arreteCadreId",
         restriction."nomGroupementAep",


### PR DESCRIPTION
## What changed

- persist approved SANDRE reports with direct FileHandle writes, fsync and deterministic cleanup
- preserve the primary write error when cleanup also fails
- cast PostgreSQL civil dates to text in both reconciliation state loaders
- defensively normalize pg Date objects before choosing the historic recompute boundary
- verify cursor debt starts at the true earliest restriction date

## Root cause

The production dry-run completed its transactional simulation and wrote a report, but the stream-backed FileHandle never completed cleanup under Node 24. The same report also recorded a null historic boundary because pg returned DATE values as Date objects while the code retained strings only.

## Validation

- backend-admin full suite: 69 suites / 999 tests
- targeted safeguards: 38/38
- PostgreSQL/PostGIS durability: 6/6
- backend-admin build
- targeted ESLint and Prettier
- git diff --check

The previous production report was deleted and must not be reused.