### PR TITLE
fix: reconcile audited SANDRE sync blockers

### DIFF
--- a/apps/backend-admin/package-lock.json
+++ b/apps/backend-admin/package-lock.json
@@ -28,6 +28,7 @@
         "archiver": "^7.0.1",
         "axios": "^1.7.3",
         "camelcase-keys": "^7.0.2",
+        "cheerio": "1.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "connect-typeorm": "^2.0.0",
@@ -5755,8 +5756,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/bowser": {
       "version": "2.14.1",
@@ -6119,7 +6119,6 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
       "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
@@ -6145,7 +6144,6 @@
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
@@ -6170,7 +6168,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -6677,7 +6674,6 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
       "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -6708,7 +6704,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       },
@@ -7129,7 +7124,6 @@
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -7147,13 +7141,11 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -7167,7 +7159,6 @@
     "node_modules/domutils": {
       "version": "3.2.2",
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -7353,7 +7344,6 @@
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
       "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "whatwg-encoding": "^3.1.1"
@@ -7367,7 +7357,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -7390,7 +7379,6 @@
     "node_modules/entities": {
       "version": "4.5.0",
       "license": "BSD-2-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -11237,7 +11225,6 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -11770,7 +11757,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -11783,7 +11769,6 @@
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
       "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "domhandler": "^5.0.3",
         "parse5": "^7.0.0"
@@ -11797,7 +11782,6 @@
       "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
       "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "parse5": "^7.0.0"
       },
@@ -11810,7 +11794,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -14910,7 +14893,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
       "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.17"
       }
@@ -15204,7 +15186,6 @@
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -15217,7 +15198,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -15230,7 +15210,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }

--- a/apps/backend-admin/package.json
+++ b/apps/backend-admin/package.json
@@ -52,6 +52,7 @@
     "archiver": "^7.0.1",
     "axios": "^1.7.3",
     "camelcase-keys": "^7.0.2",
+    "cheerio": "1.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "connect-typeorm": "^2.0.0",

--- a/apps/backend-admin/src/scripts/reconcile-sandre-zones.spec.ts
+++ b/apps/backend-admin/src/scripts/reconcile-sandre-zones.spec.ts
@@ -14,6 +14,7 @@ import {
   lockAffectedRows,
   moveOperationalReferences,
   parseCliOptions,
+  readOperationReportIfPresent,
   RECONCILIATION_REPORT_VERSION,
   SANDRE_OPERATION_REPORT_VERSION,
   releaseReconciliationResources,
@@ -253,7 +254,25 @@ describe('reconcile-sandre-zones CLI safeguards', () => {
 
   it('invalidates reports created with the previous fingerprint semantics', () => {
     expect(RECONCILIATION_REPORT_VERSION).toBe(6);
-    expect(SANDRE_OPERATION_REPORT_VERSION).toBe(3);
+    expect(SANDRE_OPERATION_REPORT_VERSION).toBe(4);
+  });
+
+  it('rejects audited operation reports from the previous evidence epoch', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'vigieau-sandre-v3-'));
+    const reportPath = join(directory, 'approved-v3.json');
+    await writeFile(
+      reportPath,
+      JSON.stringify({ kind: 'audited_sandre_operation', version: 3 }),
+      'utf8',
+    );
+
+    try {
+      await expect(readOperationReportIfPresent(reportPath)).rejects.toThrow(
+        'Unsupported operation report version 3',
+      );
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
   });
 
   it('verifies exact post-safe snapshot and global health convergence', async () => {

--- a/apps/backend-admin/src/scripts/reconcile-sandre-zones.ts
+++ b/apps/backend-admin/src/scripts/reconcile-sandre-zones.ts
@@ -29,6 +29,7 @@ import {
   reconciliationIdentity,
   ReconciliationResult,
   SANDRE_GENEALOGY_METADATA_URL,
+  SANDRE_GENEALOGY_REQUEST_HEADERS,
   SandreGenealogyRelation,
   transformDatabaseState,
   ZoneReferenceCounts,
@@ -56,7 +57,7 @@ import {
 } from '../zone_alerte/sandre-zone-reconciliation-actions';
 
 export const RECONCILIATION_REPORT_VERSION = 6;
-export const SANDRE_OPERATION_REPORT_VERSION = 3;
+export const SANDRE_OPERATION_REPORT_VERSION = 4;
 const MAX_SOURCE_SIZE = 10 * 1024 * 1024;
 const HISTORICAL_RECOMPUTE_LOCK_TIMEOUT_MS = 60 * 60 * 1000;
 
@@ -821,7 +822,10 @@ function operationOfficialSourceEvidence(
     .sort((left, right) =>
       left.departmentCode.localeCompare(right.departmentCode),
     );
-  return { snapshots, fingerprint: fingerprint(snapshots) };
+  return {
+    snapshots,
+    fingerprint: fingerprint(snapshots),
+  };
 }
 
 function assertOfficialSourceUnchanged(
@@ -1141,7 +1145,7 @@ function createOperationReport(
   };
 }
 
-async function readOperationReportIfPresent(
+export async function readOperationReportIfPresent(
   reportPath: string | null,
 ): Promise<SandreOperationReport | null> {
   if (!reportPath) {
@@ -1645,29 +1649,29 @@ export async function fetchText(
   enforceSizeLimit = true,
 ): Promise<string> {
   const response = await fetch(url, {
-    headers: {
-      accept: 'application/xml,text/xml,text/csv,text/html;q=0.9',
-      'accept-language': 'fr',
-    },
+    headers: SANDRE_GENEALOGY_REQUEST_HEADERS,
     signal: AbortSignal.timeout(60_000),
   });
   if (!response.ok) {
     throw new Error(`Unable to fetch ${url}: HTTP ${response.status}`);
   }
-  const text = await readResponseText(response, enforceSizeLimit);
+  const text = await readResponseTextWithLimit(
+    response,
+    enforceSizeLimit ? MAX_SOURCE_SIZE : null,
+  );
   if (!text) {
     throw new Error(`Invalid source size for ${url}`);
   }
   return text;
 }
 
-async function readResponseText(
+async function readResponseTextWithLimit(
   response: Response,
-  enforceSizeLimit: boolean,
+  maxBytes: number | null,
 ): Promise<string> {
   if (!response.body) {
     const text = await response.text();
-    if (enforceSizeLimit && Buffer.byteLength(text, 'utf8') > MAX_SOURCE_SIZE) {
+    if (maxBytes !== null && Buffer.byteLength(text, 'utf8') > maxBytes) {
       throw new Error('Source exceeds the configured size limit');
     }
     return text;
@@ -1684,7 +1688,7 @@ async function readResponseText(
         break;
       }
       byteCount += value.byteLength;
-      if (enforceSizeLimit && byteCount > MAX_SOURCE_SIZE) {
+      if (maxBytes !== null && byteCount > maxBytes) {
         await reader.cancel();
         throw new Error('Source exceeds the configured size limit');
       }

--- a/apps/backend-admin/src/scripts/sandre-reconciliation-plans/2026-08-15-prod-sandre-audit-blockers.json
+++ b/apps/backend-admin/src/scripts/sandre-reconciliation-plans/2026-08-15-prod-sandre-audit-blockers.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "operationId": "2026-08-15-prod-sandre-audit-blockers",
+  "description": "Resolve the second full-audit blockers with source-scoped geometry evidence and exact duplicate canonicalization.",
+  "syncExpectations": [
+    {
+      "departmentCode": "11",
+      "officialCodes": [
+        "3575",
+        "3579",
+        "3586",
+        "3592",
+        "3951",
+        "3956",
+        "3958",
+        "3961"
+      ],
+      "resolution": "geometry_normalization"
+    }
+  ],
+  "actions": [
+    {
+      "strategy": "canonicalize_duplicate",
+      "departmentCode": "49",
+      "zoneType": "SOU",
+      "sourceZoneId": 16677,
+      "targetZoneId": 9708,
+      "expectedSourceCode": "52_49_15",
+      "expectedSandreGid": 409,
+      "officialCode": "301",
+      "requiredSourceBusinessReferenceCount": 0,
+      "restrictionConflictPolicy": {
+        "mode": "prefer_source",
+        "expectedCount": 0,
+        "expectedFingerprint": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+        "allowedDifferingFields": ["niveauGravite"],
+        "requiredParentStatus": "abroge",
+        "requireSourceSeverityStrictlyHigher": true
+      }
+    }
+  ]
+}

--- a/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.spec.ts
@@ -1,0 +1,297 @@
+import { fingerprint } from './sandre-zone-reconciliation';
+import {
+  fetchSandreMdmNomenclatureEvidence,
+  fetchSandreMdmZoneRecordEvidence,
+  projectSandreMdmNomenclatureNode,
+  projectSandreMdmZoneRecord,
+  SANDRE_MDM_MAX_ZONE_RECORD_BYTES,
+  SANDRE_MDM_ZONE_RECORD_BASE_URL,
+  SandreMdmTransportResponse,
+} from './sandre-mdm-evidence';
+
+describe('Sandre MDM split evidence', () => {
+  const cases = [
+    {
+      codeSandre: '355',
+      projectionSha256:
+        'b7b16963402b459df4f882bc18962a284167d725fd05e718ca1ac68666b97504',
+      requiredEvolution: null,
+      projection: {
+        alternate: [{ value: '52_85_000014' }],
+        changed: '1786623536',
+        code: [{ value: '355' }],
+        dateCreated: [date('2024-02-08T00:00:00')],
+        dateUpdated: [date('2024-02-08T00:00:00')],
+        evolutionComments: [
+          { value: null },
+          { value: 'Importation depuis un fichier shp.' },
+        ],
+        evolutionDates: [datetime(null), datetime('2026-08-13 14:18:56')],
+        evolutionTypes: [{ nid: null }, { nid: '282834' }],
+        nid: '854735',
+        status: [{ nid: '6513' }],
+        title: '[355] Marais Sèvre Niortaise',
+        undergoes: [{ nid: null }],
+      },
+    },
+    {
+      codeSandre: '3947',
+      projectionSha256:
+        '098dd3dc60cfdda243c57446c3ae65239236f7fc7e4b6bc3bc783e262497d2fa',
+      requiredEvolution: {
+        typeNid: '282836',
+        date: '2026-06-30 00:00:00',
+        comment: 'Division de la ZAS 355',
+      },
+      projection: targetProjection({
+        code: '3947',
+        alternate: '52_85_000016',
+        changed: '1786623535',
+        nid: '1008327',
+        title: '[3947] Marais Autizes',
+        importedAt: '2026-08-13 14:18:55',
+      }),
+    },
+    {
+      codeSandre: '3948',
+      projectionSha256:
+        '7ae78c09c40975d09e3ce51bc8b7db433fd0651b178d501e38a0e112f8f59b06',
+      requiredEvolution: {
+        typeNid: '282836',
+        date: '2026-06-30 00:00:00',
+        comment: 'Division de la ZAS 355',
+      },
+      projection: targetProjection({
+        code: '3948',
+        alternate: '52_85_000017',
+        changed: '1786623533',
+        nid: '1008328',
+        title: '[3948] Marais Niortaise',
+        importedAt: '2026-08-13 14:18:52',
+      }),
+    },
+  ] as const;
+
+  it.each(cases)(
+    'accepts exact official projection $codeSandre',
+    async (item) => {
+      expect(fingerprint(item.projection)).toBe(item.projectionSha256);
+      const raw = JSON.stringify(rawRecord(item.projection));
+      await expect(
+        fetchSandreMdmZoneRecordEvidence(item, async (url) =>
+          response(url, raw),
+        ),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          codeSandre: item.codeSandre,
+          projectionSha256: item.projectionSha256,
+          byteLength: Buffer.byteLength(raw),
+        }),
+      );
+    },
+  );
+
+  it.each([
+    ['HTTP status', { status: 500 }],
+    ['media type', { contentType: 'text/html' }],
+    ['redirect', { finalUrl: 'https://example.test/redirected' }],
+  ])('rejects %s drift', async (_label, override) => {
+    const item = cases[1];
+    const url = `${SANDRE_MDM_ZONE_RECORD_BASE_URL}/${item.codeSandre}/json`;
+    await expect(
+      fetchSandreMdmZoneRecordEvidence(item, async () => ({
+        ...response(url, JSON.stringify(rawRecord(item.projection))),
+        ...override,
+      })),
+    ).rejects.toThrow('Invalid Sandre MDM response');
+  });
+
+  it('rejects size, projection and evolution drift', async () => {
+    const item = cases[1];
+    const url = `${SANDRE_MDM_ZONE_RECORD_BASE_URL}/${item.codeSandre}/json`;
+    await expect(
+      fetchSandreMdmZoneRecordEvidence(item, async () =>
+        response(url, 'x'.repeat(SANDRE_MDM_MAX_ZONE_RECORD_BYTES + 1)),
+      ),
+    ).rejects.toThrow('source size');
+
+    const projectionDrift = {
+      ...item.projection,
+      title: `${item.projection.title} drift`,
+    };
+    await expect(
+      fetchSandreMdmZoneRecordEvidence(item, async () =>
+        response(url, JSON.stringify(rawRecord(projectionDrift))),
+      ),
+    ).rejects.toThrow('projection changed');
+
+    const evolutionDrift = {
+      ...item.projection,
+      evolutionComments: [{ value: 'Division de la ZAS 356' }],
+    };
+    const driftExpectation = {
+      ...item,
+      projectionSha256: fingerprint(evolutionDrift),
+    };
+    await expect(
+      fetchSandreMdmZoneRecordEvidence(driftExpectation, async () =>
+        response(url, JSON.stringify(rawRecord(evolutionDrift))),
+      ),
+    ).rejects.toThrow('arrays are misaligned');
+  });
+
+  it('fails closed on incomplete records', () => {
+    expect(() => projectSandreMdmZoneRecord({ nid: '1' })).toThrow(
+      'Incomplete Sandre MDM zone record',
+    );
+  });
+
+  it('seals the official creation nomenclature linked by nid', async () => {
+    const expectation = {
+      nid: '282836',
+      nomenclatureCode: '590',
+      title: 'Création',
+      code: '7',
+      mnemonic: 'Création',
+      projectionSha256:
+        'a14aea447a72ba382e3645c02b89dda903c38f2b147cab46b605ff455387020d',
+    };
+    const html = nomenclatureHtml();
+    expect(
+      fingerprint(projectSandreMdmNomenclatureNode(html, '282836', '590')),
+    ).toBe(expectation.projectionSha256);
+    await expect(
+      fetchSandreMdmNomenclatureEvidence(expectation, async (url) => ({
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        finalUrl: url,
+        body: html,
+      })),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        projectionSha256: expectation.projectionSha256,
+        projection: expect.objectContaining({ code: '7', title: 'Création' }),
+      }),
+    );
+  });
+
+  it('rejects nomenclature nid, label, media and redirect drift', async () => {
+    const expectation = {
+      nid: '282836',
+      nomenclatureCode: '590',
+      title: 'Création',
+      code: '7',
+      mnemonic: 'Création',
+      projectionSha256:
+        'a14aea447a72ba382e3645c02b89dda903c38f2b147cab46b605ff455387020d',
+    };
+    const fetch = (body: string, override = {}) =>
+      fetchSandreMdmNomenclatureEvidence(expectation, async (url) => ({
+        status: 200,
+        contentType: 'text/html',
+        finalUrl: url,
+        body,
+        ...override,
+      }));
+    await expect(fetch(nomenclatureHtml('8'))).rejects.toThrow(
+      'projection changed',
+    );
+    await expect(
+      fetch(nomenclatureHtml(), { contentType: 'application/json' }),
+    ).rejects.toThrow('response');
+    await expect(
+      fetch(nomenclatureHtml(), { finalUrl: 'https://example.test/node' }),
+    ).rejects.toThrow('response');
+    expect(() =>
+      projectSandreMdmNomenclatureNode(
+        nomenclatureHtml().replace('node-282836', 'node-1'),
+        '282836',
+        '590',
+      ),
+    ).toThrow('root');
+  });
+});
+
+function nomenclatureHtml(code = '7'): string {
+  return `<!doctype html><html><body>
+    <article id="node-282836" class="node node-nsa_590">
+      <h2>Création</h2>
+      <div class="field"><div class="field-label">CdElement:</div><div class="field-item">${code}</div></div>
+      <div class="field"><div class="field-label">MnElement:</div><div class="field-item">Création</div></div>
+    </article>
+  </body></html>`;
+}
+
+function rawRecord(projection: Record<string, any>): Record<string, unknown> {
+  return {
+    nid: projection.nid,
+    title: projection.title,
+    changed: projection.changed,
+    field_zas_cdzas: projection.code,
+    field_zas_statutzas: projection.status,
+    field_zas_typeevolution: projection.evolutionTypes,
+    field_zas_dateevolution: projection.evolutionDates,
+    field_zas_comevolution: projection.evolutionComments,
+    field_zas_subitevolution: projection.undergoes,
+    field_zas_codealternatif: projection.alternate,
+    field_zas_datecreazas: projection.dateCreated,
+    field_zas_datemajzas: projection.dateUpdated,
+  };
+}
+
+function targetProjection(input: {
+  code: string;
+  alternate: string;
+  changed: string;
+  nid: string;
+  title: string;
+  importedAt: string;
+}): Record<string, unknown> {
+  return {
+    alternate: [{ value: input.alternate }],
+    changed: input.changed,
+    code: [{ value: input.code }],
+    dateCreated: [date('2026-06-30T00:00:00')],
+    dateUpdated: [date('2026-06-30T00:00:00')],
+    evolutionComments: [
+      { value: 'Division de la ZAS 355' },
+      { value: 'Importation depuis un fichier shp.' },
+    ],
+    evolutionDates: [
+      datetime('2026-06-30 00:00:00'),
+      datetime(input.importedAt),
+    ],
+    evolutionTypes: [{ nid: '282836' }, { nid: '282834' }],
+    nid: input.nid,
+    status: [{ nid: '6514' }],
+    title: input.title,
+    undergoes: [{ nid: null }],
+  };
+}
+
+function date(value: string): Record<string, unknown> {
+  return {
+    date_type: 'date',
+    timezone: 'Europe/Paris',
+    timezone_db: 'Europe/Paris',
+    value,
+  };
+}
+
+function datetime(value: string | null): Record<string, unknown> {
+  return {
+    date_type: 'datetime',
+    timezone: 'Europe/Paris',
+    timezone_db: 'Europe/Paris',
+    value,
+  };
+}
+
+function response(url: string, body: string): SandreMdmTransportResponse {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    finalUrl: url,
+    body,
+  };
+}

--- a/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.ts
@@ -1,0 +1,257 @@
+import { createHash } from 'crypto';
+import { load } from 'cheerio';
+import { fingerprint } from './sandre-zone-reconciliation';
+import {
+  SandreMdmNomenclatureExpectation,
+  SandreMdmZoneExpectation,
+} from './sandre-zone-sync-approvals';
+
+export const SANDRE_MDM_ZONE_RECORD_BASE_URL =
+  'https://mdm.sandre.eaufrance.fr/id/zonealertesechresse';
+export const SANDRE_MDM_MAX_ZONE_RECORD_BYTES = 2 * 1024 * 1024;
+export const SANDRE_MDM_NOMENCLATURE_NODE_BASE_URL =
+  'https://mdm.sandre.eaufrance.fr/node';
+export const SANDRE_MDM_MAX_NOMENCLATURE_BYTES = 512 * 1024;
+
+export interface SandreMdmTransportResponse {
+  status: number;
+  contentType: string | null;
+  finalUrl: string;
+  body: string;
+}
+
+export interface SandreMdmZoneRecordEvidence {
+  codeSandre: string;
+  url: string;
+  byteLength: number;
+  rawSha256: string;
+  projection: 'zone_alert_evolution_v1';
+  projectionSha256: string;
+  requiredEvolution: SandreMdmZoneExpectation['requiredEvolution'];
+}
+
+export interface SandreMdmNomenclatureEvidence {
+  url: string;
+  byteLength: number;
+  rawSha256: string;
+  projection: {
+    nid: string;
+    nomenclatureCode: string;
+    title: string;
+    code: string;
+    mnemonic: string;
+  };
+  projectionSha256: string;
+}
+
+export async function fetchSandreMdmZoneRecordEvidence(
+  expectation: SandreMdmZoneExpectation,
+  transport: (url: string) => Promise<SandreMdmTransportResponse>,
+): Promise<SandreMdmZoneRecordEvidence> {
+  if (!/^\d{1,32}$/.test(expectation.codeSandre)) {
+    throw new Error('Invalid Sandre MDM zone code');
+  }
+  const url = `${SANDRE_MDM_ZONE_RECORD_BASE_URL}/${expectation.codeSandre}/json`;
+  const response = await transport(url);
+  if (
+    response.status !== 200 ||
+    response.finalUrl !== url ||
+    response.contentType?.split(';', 1)[0].trim().toLowerCase() !==
+      'application/json'
+  ) {
+    throw new Error(
+      `Invalid Sandre MDM response for zone ${expectation.codeSandre}`,
+    );
+  }
+  const byteLength = Buffer.byteLength(response.body, 'utf8');
+  if (byteLength === 0 || byteLength > SANDRE_MDM_MAX_ZONE_RECORD_BYTES) {
+    throw new Error(
+      `Invalid Sandre MDM source size for zone ${expectation.codeSandre}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(response.body);
+  } catch {
+    throw new Error(
+      `Invalid Sandre MDM JSON for zone ${expectation.codeSandre}`,
+    );
+  }
+  const projection = projectSandreMdmZoneRecord(parsed);
+  const codeValues = projection.code as Array<Record<string, unknown>>;
+  if (
+    codeValues.length !== 1 ||
+    codeValues[0]?.value !== expectation.codeSandre
+  ) {
+    throw new Error(
+      `Sandre MDM zone code mismatch for ${expectation.codeSandre}`,
+    );
+  }
+  const projectionSha256 = fingerprint(projection);
+  if (projectionSha256 !== expectation.projectionSha256) {
+    throw new Error(
+      `Sandre MDM projection changed for zone ${expectation.codeSandre}`,
+    );
+  }
+  if (expectation.requiredEvolution) {
+    assertSandreMdmEvolution(projection, expectation.requiredEvolution);
+  }
+  return {
+    codeSandre: expectation.codeSandre,
+    url,
+    byteLength,
+    rawSha256: createHash('sha256').update(response.body).digest('hex'),
+    projection: 'zone_alert_evolution_v1',
+    projectionSha256,
+    requiredEvolution: expectation.requiredEvolution,
+  };
+}
+
+export async function fetchSandreMdmNomenclatureEvidence(
+  expectation: SandreMdmNomenclatureExpectation,
+  transport: (url: string) => Promise<SandreMdmTransportResponse>,
+): Promise<SandreMdmNomenclatureEvidence> {
+  const url = `${SANDRE_MDM_NOMENCLATURE_NODE_BASE_URL}/${expectation.nid}`;
+  const response = await transport(url);
+  const mediaType = response.contentType?.split(';', 1)[0].trim().toLowerCase();
+  if (
+    response.status !== 200 ||
+    response.finalUrl !== url ||
+    (mediaType !== 'text/html' && mediaType !== 'application/xhtml+xml')
+  ) {
+    throw new Error('Invalid Sandre MDM nomenclature response');
+  }
+  const byteLength = Buffer.byteLength(response.body, 'utf8');
+  if (byteLength === 0 || byteLength > SANDRE_MDM_MAX_NOMENCLATURE_BYTES) {
+    throw new Error('Invalid Sandre MDM nomenclature source size');
+  }
+  const projection = projectSandreMdmNomenclatureNode(
+    response.body,
+    expectation.nid,
+    expectation.nomenclatureCode,
+  );
+  const projectionSha256 = fingerprint(projection);
+  if (projectionSha256 !== expectation.projectionSha256) {
+    throw new Error('Sandre MDM nomenclature projection changed');
+  }
+  return {
+    url,
+    byteLength,
+    rawSha256: createHash('sha256').update(response.body).digest('hex'),
+    projection,
+    projectionSha256,
+  };
+}
+
+export function projectSandreMdmNomenclatureNode(
+  html: string,
+  nid: string,
+  nomenclatureCode: string,
+): SandreMdmNomenclatureEvidence['projection'] {
+  const $ = load(html);
+  const root = $(`#node-${nid}.node-nsa_${nomenclatureCode}`);
+  if (root.length !== 1) {
+    throw new Error('Invalid Sandre MDM nomenclature root');
+  }
+  const titles = root.find('h2');
+  if (titles.length !== 1) {
+    throw new Error('Invalid Sandre MDM nomenclature title');
+  }
+  const fieldValue = (label: string): string => {
+    const fields = root.find('.field').filter((_index, field) => {
+      const labels = $(field).find('.field-label');
+      return (
+        labels.length === 1 &&
+        labels.first().text().replace(/\s+/g, ' ').trim() === `${label}:`
+      );
+    });
+    if (fields.length !== 1) {
+      throw new Error(`Invalid Sandre MDM nomenclature field ${label}`);
+    }
+    const items = fields.first().find('.field-item');
+    if (items.length !== 1) {
+      throw new Error(`Invalid Sandre MDM nomenclature value ${label}`);
+    }
+    return items.first().text().replace(/\s+/g, ' ').trim();
+  };
+  return {
+    nid,
+    nomenclatureCode,
+    title: titles.first().text().replace(/\s+/g, ' ').trim(),
+    code: fieldValue('CdElement'),
+    mnemonic: fieldValue('MnElement'),
+  };
+}
+
+export function projectSandreMdmZoneRecord(
+  value: unknown,
+): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid Sandre MDM zone record');
+  }
+  const record = value as Record<string, unknown>;
+  const requiredKeys = [
+    'nid',
+    'title',
+    'changed',
+    'field_zas_cdzas',
+    'field_zas_statutzas',
+    'field_zas_typeevolution',
+    'field_zas_dateevolution',
+    'field_zas_comevolution',
+    'field_zas_subitevolution',
+    'field_zas_codealternatif',
+    'field_zas_datecreazas',
+    'field_zas_datemajzas',
+  ];
+  if (
+    requiredKeys.some(
+      (key) => !Object.prototype.hasOwnProperty.call(record, key),
+    ) ||
+    typeof record.nid !== 'string' ||
+    typeof record.title !== 'string' ||
+    typeof record.changed !== 'string' ||
+    requiredKeys
+      .filter((key) => !['nid', 'title', 'changed'].includes(key))
+      .some((key) => !Array.isArray(record[key]))
+  ) {
+    throw new Error('Incomplete Sandre MDM zone record');
+  }
+  return {
+    nid: record.nid,
+    title: record.title,
+    changed: record.changed,
+    code: record.field_zas_cdzas,
+    status: record.field_zas_statutzas,
+    evolutionTypes: record.field_zas_typeevolution,
+    evolutionDates: record.field_zas_dateevolution,
+    evolutionComments: record.field_zas_comevolution,
+    undergoes: record.field_zas_subitevolution,
+    alternate: record.field_zas_codealternatif,
+    dateCreated: record.field_zas_datecreazas,
+    dateUpdated: record.field_zas_datemajzas,
+  };
+}
+
+function assertSandreMdmEvolution(
+  projection: Record<string, unknown>,
+  expected: NonNullable<SandreMdmZoneExpectation['requiredEvolution']>,
+): void {
+  const types = projection.evolutionTypes as Array<Record<string, unknown>>;
+  const dates = projection.evolutionDates as Array<Record<string, unknown>>;
+  const comments = projection.evolutionComments as Array<
+    Record<string, unknown>
+  >;
+  if (types.length !== dates.length || types.length !== comments.length) {
+    throw new Error('Sandre MDM evolution arrays are misaligned');
+  }
+  const matches = types.filter(
+    (type, index) =>
+      type?.nid === expected.typeNid &&
+      dates[index]?.value === expected.date &&
+      comments[index]?.value === expected.comment,
+  );
+  if (matches.length !== 1) {
+    throw new Error('Expected exactly one Sandre MDM split evolution');
+  }
+}

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-durability.postgres.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-durability.postgres.spec.ts
@@ -12,6 +12,17 @@ import {
 import { normalizeSandreZoneGeometries } from './sandre-zone-geometry';
 import { fingerprint } from './sandre-zone-reconciliation';
 import {
+  assertSandreApprovedMaterializedTargets,
+  auditSandreApprovedSyncGeometry,
+  SandreApprovedSyncMapping,
+} from './sandre-zone-sync-approvals';
+import {
+  applySandreApprovedPartitionReferences,
+  loadSandreApprovedReferenceEvidence,
+  lockSandreApprovedSyncReferences,
+  markSandreApprovedHistoricalRecomputeDebt,
+} from './sandre-zone-sync-approved-references';
+import {
   applySandreReconciliationActions,
   auditSandreReconciliationPlan,
   loadSandreReconciliationState,
@@ -48,7 +59,10 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
       CREATE TABLE config (
         id integer PRIMARY KEY,
         "computeMapDate" date,
-        "computeStatsDate" date
+        "computeMapGeneration" bigint NOT NULL DEFAULT 0,
+        "computeStatsDate" date,
+        "computeStatsGeneration" bigint NOT NULL DEFAULT 0,
+        "historicComputeEpoch" bigint NOT NULL DEFAULT 0
       );
       CREATE TABLE sandre_zone_sync_state (
         id serial PRIMARY KEY,
@@ -98,7 +112,7 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
         "dateDebut" date
       );
       CREATE TABLE restriction (
-        id integer PRIMARY KEY,
+        id serial PRIMARY KEY,
         "arreteRestrictionId" integer NOT NULL
           REFERENCES arrete_restriction(id),
         "zoneAlerteId" integer NOT NULL REFERENCES zone_alerte(id),
@@ -108,13 +122,22 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
         UNIQUE ("arreteRestrictionId", "zoneAlerteId")
       );
       CREATE TABLE usage (
-        id integer PRIMARY KEY,
+        id serial PRIMARY KEY,
         nom text NOT NULL,
         "thematiqueId" integer NOT NULL,
         "restrictionId" integer REFERENCES restriction(id) ON DELETE CASCADE,
         "arreteCadreId" integer,
         "isTemplate" boolean NOT NULL DEFAULT false,
         "concerneParticulier" boolean,
+        "concerneEntreprise" boolean,
+        "concerneCollectivite" boolean,
+        "concerneExploitation" boolean,
+        "concerneEso" boolean NOT NULL DEFAULT true,
+        "concerneEsu" boolean NOT NULL DEFAULT true,
+        "concerneAep" boolean NOT NULL DEFAULT true,
+        "descriptionVigilance" text,
+        "descriptionAlerte" text,
+        "descriptionAlerteRenforcee" text,
         "descriptionCrise" text,
         UNIQUE (nom, "thematiqueId", "restrictionId")
       );
@@ -123,6 +146,14 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
           ON DELETE CASCADE,
         "communeId" integer NOT NULL,
         PRIMARY KEY ("restrictionId", "communeId")
+      );
+      CREATE TABLE zone_alerte_computed (
+        id integer PRIMARY KEY,
+        "restrictionId" integer REFERENCES restriction(id) ON DELETE CASCADE
+      );
+      CREATE TABLE zone_alerte_computed_historic (
+        id integer PRIMARY KEY,
+        "restrictionId" integer REFERENCES restriction(id) ON DELETE CASCADE
       );
       CREATE TABLE arrete_cadre_zone_alerte_communes (
         id integer PRIMARY KEY,
@@ -219,6 +250,13 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
       expect(result.audits.get(code)!.relativeAreaDelta).toBeLessThanOrEqual(
         1e-9,
       );
+      expect(
+        result.audits.get(code)!.absoluteGeodesicAreaDeltaSquareMeters,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        Number.isFinite(result.audits.get(code)!.rawGeodesicAreaSquareMeters),
+      ).toBe(true);
+      expect(result.audits.get(code)!.normalizationApprovalId).toBeNull();
     }
   });
 
@@ -539,6 +577,551 @@ describeWithPostgres('Sandre durable reconciliation on PostgreSQL', () => {
     } finally {
       await runner.rollbackTransaction();
     }
+  }, 30_000);
+
+  it('canonicalizes an exact duplicate with a zero-conflict policy', async () => {
+    await runner.query(`
+      INSERT INTO zone_alerte (
+        id, "departementId", type, code, "idSandre", disabled, geom,
+        "sandreProvenance"
+      ) VALUES
+        (9708, 49, 'SOU', '52_49_15', 409, false,
+          ST_GeomFromText('POLYGON((4 0,6 0,6 2,4 2,4 0))', 4326),
+          'legacy_unverified'),
+        (16677, 49, 'SOU', '52_49_15', 409, false,
+          ST_GeomFromText('POLYGON((4 0,6 0,6 2,4 2,4 0))', 4326),
+          'legacy_unverified');
+      INSERT INTO arrete_cadre (id, statut) VALUES (20, 'publie');
+      INSERT INTO arrete_cadre_zone_alerte (
+        "arreteCadreId", "zoneAlerteId"
+      ) VALUES (20, 9708);
+      INSERT INTO arrete_restriction (id, statut, "dateDebut")
+      VALUES (20, 'a_valider', DATE '2026-06-22');
+      INSERT INTO restriction (
+        id, "arreteRestrictionId", "zoneAlerteId", "arreteCadreId",
+        "niveauGravite"
+      ) VALUES (200, 20, 9708, 20, 'alerte');
+    `);
+    const plan = parseSandreReconciliationPlan({
+      schemaVersion: 1,
+      operationId: 'postgres-zero-conflict-duplicate',
+      description: 'PostgreSQL zero-conflict duplicate fixture',
+      actions: [
+        {
+          strategy: 'canonicalize_duplicate',
+          departmentCode: '49',
+          zoneType: 'SOU',
+          sourceZoneId: 16677,
+          targetZoneId: 9708,
+          expectedSourceCode: '52_49_15',
+          expectedSandreGid: 409,
+          officialCode: '301',
+          restrictionConflictPolicy: {
+            mode: 'prefer_source',
+            expectedCount: 0,
+            expectedFingerprint: fingerprint([]),
+            allowedDifferingFields: ['niveauGravite'],
+            requiredParentStatus: 'abroge',
+            requireSourceSeverityStrictlyHigher: true,
+          },
+        },
+      ],
+    });
+    const official = [officialAubanceFeature()];
+
+    const audits = await auditSandreReconciliationPlan(runner, plan, official);
+    expect(audits).toEqual([
+      expect.objectContaining({
+        status: 'ready',
+        restrictionConflicts: {
+          policy: 'prefer_source',
+          count: 0,
+          fingerprint: fingerprint([]),
+        },
+        geometry: expect.objectContaining({
+          officialCode: '301',
+          officialGid: 409,
+          targetEqualsOfficial: true,
+          sourceCoverage: 1,
+          targetCoverage: 1,
+          iou: 1,
+        }),
+      }),
+    ]);
+
+    await runner.startTransaction('SERIALIZABLE');
+    try {
+      await lockSandreReconciliationPlan(runner, plan);
+      await applySandreReconciliationActions(runner, audits);
+      await runner.commitTransaction();
+    } catch (error) {
+      await runner.rollbackTransaction();
+      throw error;
+    }
+
+    const [state] = await runner.query(`
+      SELECT
+        source.disabled AS "sourceDisabled",
+        source."idSandre" AS "sourceGid",
+        source."sandreProvenance" AS "sourceProvenance",
+        (SELECT count(*)::integer FROM arrete_cadre_zone_alerte
+          WHERE "zoneAlerteId" = 16677) AS "sourceFrameworks",
+        (SELECT count(*)::integer FROM restriction
+          WHERE "zoneAlerteId" = 16677) AS "sourceRestrictions",
+        (SELECT count(*)::integer FROM arrete_cadre_zone_alerte
+          WHERE "zoneAlerteId" = 9708) AS "targetFrameworks",
+        (SELECT count(*)::integer FROM restriction
+          WHERE "zoneAlerteId" = 9708) AS "targetRestrictions"
+      FROM zone_alerte source
+      WHERE source.id = 16677
+    `);
+    expect(state).toEqual({
+      sourceDisabled: true,
+      sourceGid: null,
+      sourceProvenance: 'legacy_unverified',
+      sourceFrameworks: 0,
+      sourceRestrictions: 0,
+      targetFrameworks: 1,
+      targetRestrictions: 1,
+    });
+    await expect(
+      auditSandreReconciliationPlan(runner, plan, official),
+    ).resolves.toEqual([
+      expect.objectContaining({ status: 'already_applied' }),
+    ]);
+  }, 30_000);
+
+  it('preserves restriction history while applying and replaying an approved sync split', async () => {
+    await runner.query(`
+      INSERT INTO departement (id, code) VALUES (86, '86');
+      INSERT INTO config (
+        id, "computeMapDate", "computeMapGeneration", "computeStatsDate",
+        "computeStatsGeneration", "historicComputeEpoch"
+      ) VALUES (1, DATE '2026-08-15', 7, DATE '2026-08-15', 8, 9)
+      ON CONFLICT (id) DO UPDATE SET
+        "computeMapDate" = EXCLUDED."computeMapDate",
+        "computeMapGeneration" = EXCLUDED."computeMapGeneration",
+        "computeStatsDate" = EXCLUDED."computeStatsDate",
+        "computeStatsGeneration" = EXCLUDED."computeStatsGeneration",
+        "historicComputeEpoch" = EXCLUDED."historicComputeEpoch";
+      INSERT INTO zone_alerte (
+        id, "departementId", type, code, "idSandre", "codeSandre",
+        disabled, geom, "sandreProvenance"
+      ) VALUES
+        (20582, 86, 'SUP', 'SOURCE', 464, '355', true,
+          ST_GeomFromText('POLYGON((0 8,2 8,2 10,0 10,0 8))', 4326),
+          'official'),
+        (20583, 86, 'SUP', 'TARGET-A', 3947, '3947', false,
+          ST_GeomFromText('POLYGON((0 8,1 8,1 10,0 10,0 8))', 4326),
+          'official'),
+        (20584, 86, 'SUP', 'TARGET-B', 3946, '3948', false,
+          ST_GeomFromText('POLYGON((1 8,2 8,2 10,1 10,1 8))', 4326),
+          'official');
+      INSERT INTO arrete_cadre (id, statut) VALUES
+        (130, 'publie'),
+        (131, 'abroge');
+      INSERT INTO arrete_cadre_zone_alerte (
+        "arreteCadreId", "zoneAlerteId"
+      ) VALUES (130, 20582), (131, 20582);
+      INSERT INTO arrete_restriction (id, statut, "dateDebut") VALUES
+        (130, 'publie', DATE '2026-05-01'),
+        (131, 'a_venir', DATE '2026-07-01'),
+        (132, 'abroge', DATE '2025-01-01');
+      INSERT INTO restriction (
+        id, "arreteRestrictionId", "zoneAlerteId", "arreteCadreId",
+        "nomGroupementAep", "niveauGravite"
+      ) VALUES
+        (1300, 130, 20582, 130, NULL, 'alerte_renforcee'),
+        (1301, 131, 20582, 130, 'GROUPEMENT', 'crise'),
+        (1302, 132, 20582, 131, NULL, 'alerte');
+      INSERT INTO usage (
+        id, nom, "thematiqueId", "restrictionId", "arreteCadreId",
+        "isTemplate", "concerneParticulier", "concerneEntreprise",
+        "concerneCollectivite", "concerneExploitation", "concerneEso",
+        "concerneEsu", "concerneAep", "descriptionAlerte",
+        "descriptionCrise"
+      ) VALUES
+        (1300, 'Usage split A', 1, 1300, NULL, false, true, false, false,
+          false, true, true, false, 'Alerte A', 'Crise A'),
+        (1301, 'Usage split B', 2, 1301, NULL, false, false, true, true,
+          false, false, true, true, 'Alerte B', 'Crise B'),
+        (1302, 'Usage historique', 3, 1302, NULL, false, false, false,
+          false, false, true, true, true, 'Historique', 'Historique');
+      INSERT INTO restriction_commune ("restrictionId", "communeId") VALUES
+        (1300, 86001), (1300, 86002), (1301, 86003), (1302, 86004);
+      INSERT INTO zone_alerte_computed (id, "restrictionId") VALUES
+        (1300, 1300), (1301, 1301);
+      INSERT INTO zone_alerte_computed_historic (id, "restrictionId") VALUES
+        (2300, 1300), (2301, 1301), (2302, 1302);
+      SELECT setval(
+        pg_get_serial_sequence('restriction', 'id'),
+        (SELECT max(id) FROM restriction)
+      );
+      SELECT setval(
+        pg_get_serial_sequence('usage', 'id'),
+        (SELECT max(id) FROM usage)
+      );
+    `);
+    const expected = await loadSandreApprovedReferenceEvidence(
+      runner,
+      20582,
+      [20583, 20584],
+    );
+    expect(
+      expected.restrictions.map((restriction) => restriction.restrictionId),
+    ).toEqual([1300, 1301]);
+
+    await runner.startTransaction('SERIALIZABLE');
+    try {
+      await lockSandreApprovedSyncReferences(runner, [20582], [20583, 20584]);
+      await expect(
+        applySandreApprovedPartitionReferences(
+          runner,
+          expected,
+          [
+            { codeSandre: '3948', zoneAlerteId: 20584 },
+            { codeSandre: '3947', zoneAlerteId: 20583 },
+          ],
+          '2026-06-30',
+        ),
+      ).resolves.toEqual({ applied: true });
+      await runner.commitTransaction();
+    } catch (error) {
+      await runner.rollbackTransaction();
+      throw error;
+    }
+
+    const restrictions = await runner.query(`
+      SELECT id, "zoneAlerteId", "arreteRestrictionId"
+      FROM restriction
+      WHERE "arreteRestrictionId" IN (130, 131, 132)
+      ORDER BY "arreteRestrictionId", "zoneAlerteId"
+    `);
+    expect(restrictions).toEqual([
+      { id: 1300, zoneAlerteId: 20583, arreteRestrictionId: 130 },
+      {
+        id: expect.any(Number),
+        zoneAlerteId: 20584,
+        arreteRestrictionId: 130,
+      },
+      { id: 1301, zoneAlerteId: 20583, arreteRestrictionId: 131 },
+      {
+        id: expect.any(Number),
+        zoneAlerteId: 20584,
+        arreteRestrictionId: 131,
+      },
+      { id: 1302, zoneAlerteId: 20582, arreteRestrictionId: 132 },
+    ]);
+    const computed = await runner.query(`
+      SELECT 'current' AS kind, id, "restrictionId"
+      FROM zone_alerte_computed
+      UNION ALL
+      SELECT 'historic' AS kind, id, "restrictionId"
+      FROM zone_alerte_computed_historic
+      ORDER BY kind, id
+    `);
+    expect(computed).toEqual(
+      expect.arrayContaining([
+        { kind: 'current', id: 1300, restrictionId: 1300 },
+        { kind: 'current', id: 1301, restrictionId: 1301 },
+        { kind: 'historic', id: 2300, restrictionId: 1300 },
+        { kind: 'historic', id: 2301, restrictionId: 1301 },
+        { kind: 'historic', id: 2302, restrictionId: 1302 },
+      ]),
+    );
+    const cloneRestrictionIds = restrictions
+      .filter((row) => row.zoneAlerteId === 20584)
+      .map((row) => Number(row.id));
+    expect(cloneRestrictionIds).toHaveLength(2);
+    expect(
+      computed.filter((row) => cloneRestrictionIds.includes(row.restrictionId)),
+    ).toEqual([]);
+    await runner.query(
+      `
+        INSERT INTO zone_alerte_computed (id, "restrictionId") VALUES
+          (91300, $1), (91301, $2)
+      `,
+      cloneRestrictionIds,
+    );
+    await runner.query(
+      `
+        INSERT INTO zone_alerte_computed_historic (id, "restrictionId") VALUES
+          (92300, $1), (92301, $2)
+      `,
+      cloneRestrictionIds,
+    );
+    const initialLineage = await loadSandreApprovedReferenceEvidence(
+      runner,
+      20582,
+      [20583, 20584],
+      expected,
+    );
+    expect(initialLineage.lifecycle).toBe('post_apply');
+    const [cursor] = await runner.query(`
+      SELECT
+        "computeMapDate"::text AS "computeMapDate",
+        "computeMapGeneration"::integer AS "computeMapGeneration",
+        "computeStatsDate"::text AS "computeStatsDate",
+        "computeStatsGeneration"::integer AS "computeStatsGeneration",
+        "historicComputeEpoch"::integer AS "historicComputeEpoch"
+      FROM config WHERE id = 1
+    `);
+    expect(cursor).toEqual({
+      computeMapDate: '2026-06-30',
+      computeMapGeneration: 8,
+      computeStatsDate: '2026-06-30',
+      computeStatsGeneration: 9,
+      historicComputeEpoch: 10,
+    });
+
+    await runner.startTransaction('SERIALIZABLE');
+    try {
+      await lockSandreApprovedSyncReferences(runner, [20582], [20583, 20584]);
+      await expect(
+        applySandreApprovedPartitionReferences(
+          runner,
+          expected,
+          [
+            { codeSandre: '3947', zoneAlerteId: 20583 },
+            { codeSandre: '3948', zoneAlerteId: 20584 },
+          ],
+          '2026-06-30',
+        ),
+      ).resolves.toEqual({ applied: false });
+      await markSandreApprovedHistoricalRecomputeDebt(runner, '2026-08-01');
+      await runner.commitTransaction();
+    } catch (error) {
+      await runner.rollbackTransaction();
+      throw error;
+    }
+    const [replayedCursor] = await runner.query(`
+      SELECT
+        "computeMapGeneration"::integer AS map,
+        "computeStatsGeneration"::integer AS stats,
+        "historicComputeEpoch"::integer AS epoch
+      FROM config WHERE id = 1
+    `);
+    expect(replayedCursor).toEqual({ map: 8, stats: 9, epoch: 10 });
+
+    await runner.query(`
+      INSERT INTO arrete_cadre (id, statut) VALUES (86130, 'publie');
+      INSERT INTO arrete_cadre_zone_alerte (
+        "arreteCadreId", "zoneAlerteId"
+      ) VALUES (86130, 20584);
+      INSERT INTO arrete_restriction (id, statut, "dateDebut")
+      VALUES (86130, 'publie', DATE '2026-08-10');
+    `);
+    const [futureRestriction] = await runner.query(`
+      INSERT INTO restriction (
+        "arreteRestrictionId", "zoneAlerteId", "arreteCadreId",
+        "nomGroupementAep", "niveauGravite"
+      ) VALUES (86130, 20584, 86130, NULL, 'alerte')
+      RETURNING id
+    `);
+    const auditedFutureState = await loadSandreApprovedReferenceEvidence(
+      runner,
+      20582,
+      [20583, 20584],
+      initialLineage,
+    );
+    expect(auditedFutureState.lifecycle).toBe('post_apply');
+    expect(auditedFutureState.fingerprint).not.toBe(initialLineage.fingerprint);
+    await expect(
+      applySandreApprovedPartitionReferences(
+        runner,
+        auditedFutureState,
+        [
+          { codeSandre: '3947', zoneAlerteId: 20583 },
+          { codeSandre: '3948', zoneAlerteId: 20584 },
+        ],
+        '2026-06-30',
+      ),
+    ).resolves.toEqual({ applied: false });
+
+    await runner.query(
+      `UPDATE restriction SET "niveauGravite" = 'crise' WHERE id = $1`,
+      [futureRestriction.id],
+    );
+    await expect(
+      applySandreApprovedPartitionReferences(
+        runner,
+        auditedFutureState,
+        [
+          { codeSandre: '3947', zoneAlerteId: 20583 },
+          { codeSandre: '3948', zoneAlerteId: 20584 },
+        ],
+        '2026-06-30',
+      ),
+    ).rejects.toThrow('restriction lineage is incomplete');
+    await runner.query(
+      `UPDATE restriction SET "niveauGravite" = 'alerte' WHERE id = $1`,
+      [futureRestriction.id],
+    );
+
+    await runner.query(
+      `UPDATE restriction SET "niveauGravite" = 'crise' WHERE id = $1`,
+      [cloneRestrictionIds[0]],
+    );
+    await expect(
+      loadSandreApprovedReferenceEvidence(
+        runner,
+        20582,
+        [20583, 20584],
+        initialLineage,
+      ),
+    ).rejects.toThrow('restriction lineage is incomplete');
+    await runner.query(
+      `UPDATE restriction SET "niveauGravite" = 'alerte_renforcee' WHERE id = $1`,
+      [cloneRestrictionIds[0]],
+    );
+
+    await runner.query(`
+      UPDATE arrete_cadre SET statut = 'abroge' WHERE id = 130;
+      UPDATE arrete_restriction SET statut = 'abroge' WHERE id = 130;
+    `);
+    await expect(
+      loadSandreApprovedReferenceEvidence(
+        runner,
+        20582,
+        [20583, 20584],
+        initialLineage,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ lifecycle: 'post_apply' }));
+
+    await runner.query(`
+      INSERT INTO arrete_cadre_zone_alerte_communes (
+        id, "arreteCadreId", "zoneAlerteId"
+      ) VALUES (86130, 86130, 20582)
+    `);
+    await expect(
+      loadSandreApprovedReferenceEvidence(
+        runner,
+        20582,
+        [20583, 20584],
+        initialLineage,
+      ),
+    ).rejects.toThrow('source regained operational references');
+    await runner.query(
+      `DELETE FROM arrete_cadre_zone_alerte_communes WHERE id = 86130`,
+    );
+  }, 30_000);
+
+  it('pins approved split geometry and its materialized target rows', async () => {
+    await runner.query(
+      `UPDATE zone_alerte SET geom = ST_Multi(geom) WHERE id IN (20583, 20584)`,
+    );
+    const targetFeatures = [
+      {
+        codeSandre: '3947',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 8],
+              [1, 8],
+              [1, 10],
+              [0, 10],
+              [0, 8],
+            ],
+          ],
+        },
+      },
+      {
+        codeSandre: '3948',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [1, 8],
+              [2, 8],
+              [2, 10],
+              [1, 10],
+              [1, 8],
+            ],
+          ],
+        },
+      },
+    ] as any[];
+    const mapping: SandreApprovedSyncMapping = {
+      sourceCode: '355',
+      sourceZoneId: 20582,
+      targetCodes: ['3947', '3948'],
+      requireTopologicalEquality: false,
+      effectiveDate: '2026-06-30',
+      expectedGeometry: null,
+      minimumGeometry: {
+        sourceCoverage: 0.9999,
+        targetCoverage: 0.9999,
+        iou: 0.9999,
+      },
+    };
+    const observed = await auditSandreApprovedSyncGeometry(
+      runner,
+      mapping,
+      targetFeatures,
+    );
+    expect(observed).toEqual(
+      expect.objectContaining({
+        sourceCoverage: 1,
+        targetCoverage: 1,
+        iou: 1,
+        pairwiseOverlapRatio: 0,
+        topologicallyEqual: true,
+      }),
+    );
+    const pinned: SandreApprovedSyncMapping = {
+      ...mapping,
+      expectedGeometry: {
+        sourceGeometryHash: observed.sourceGeometryHash,
+        targetGeometryHashes: observed.targetGeometryHashes,
+        unionGeometryHash: observed.unionGeometryHash,
+        sourceCoverage: observed.sourceCoverage,
+        targetCoverage: observed.targetCoverage,
+        iou: observed.iou,
+      },
+    };
+    await expect(
+      auditSandreApprovedSyncGeometry(runner, pinned, targetFeatures),
+    ).resolves.toEqual(observed);
+    await expect(
+      assertSandreApprovedMaterializedTargets(runner, 86, [
+        { feature: targetFeatures[0], zoneAlerteId: 20583 },
+        { feature: targetFeatures[1], zoneAlerteId: 20584 },
+      ]),
+    ).resolves.toBeUndefined();
+
+    const [stored] = await runner.query(`
+      SELECT
+        ST_AsEWKB(source.geom) AS source,
+        ST_AsEWKB(target.geom) AS target
+      FROM zone_alerte source
+      CROSS JOIN zone_alerte target
+      WHERE source.id = 20582 AND target.id = 20583
+    `);
+    await runner.query(
+      `UPDATE zone_alerte SET geom = ST_Translate(geom, 0.000001, 0) WHERE id = 20582`,
+    );
+    await expect(
+      auditSandreApprovedSyncGeometry(runner, pinned, targetFeatures),
+    ).rejects.toThrow('Approved Sandre geometry changed');
+    await runner.query(
+      `UPDATE zone_alerte SET geom = ST_GeomFromEWKB($1) WHERE id = 20582`,
+      [stored.source],
+    );
+
+    await runner.query(
+      `UPDATE zone_alerte SET geom = ST_Translate(geom, 0.000001, 0) WHERE id = 20583`,
+    );
+    await expect(
+      assertSandreApprovedMaterializedTargets(runner, 86, [
+        { feature: targetFeatures[0], zoneAlerteId: 20583 },
+        { feature: targetFeatures[1], zoneAlerteId: 20584 },
+      ]),
+    ).rejects.toThrow('materialized target geometry changed');
+    await runner.query(
+      `UPDATE zone_alerte SET geom = ST_GeomFromEWKB($1) WHERE id = 20583`,
+      [stored.target],
+    );
   }, 30_000);
 
   it('persists the historical cursors and resumes an existing recompute debt', async () => {
@@ -909,6 +1492,30 @@ function officialErdreFeature(): any {
           [2, 2],
           [0, 2],
           [0, 0],
+        ],
+      ],
+    },
+  };
+}
+
+function officialAubanceFeature(): any {
+  return {
+    codeSandre: '301',
+    gid: 409,
+    departmentCode: '49',
+    type: 'SOU',
+    status: 'Validé',
+    payloadHash: 'official-301-hash',
+    basinCode: 1,
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [4, 0],
+          [6, 0],
+          [6, 2],
+          [4, 2],
+          [4, 0],
         ],
       ],
     },

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-geometry-approvals.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-geometry-approvals.spec.ts
@@ -1,0 +1,107 @@
+import {
+  findSandreGeometryNormalizationApproval,
+  SANDRE_GEOMETRY_NORMALIZATION_APPROVALS,
+  SandreGeometryNormalizationCandidate,
+  SandreGeometryNormalizationContext,
+} from './sandre-zone-geometry-approvals';
+
+describe('audited Sandre geometry normalization approvals', () => {
+  const approval = SANDRE_GEOMETRY_NORMALIZATION_APPROVALS[0];
+  const feature = approval.features.find((item) => item.codeSandre === '3958')!;
+  const context: SandreGeometryNormalizationContext = {
+    departmentCode: approval.departmentCode,
+    snapshotHash: approval.snapshotHash,
+    sourceUpdatedAt: approval.sourceUpdatedAt,
+    featureCount: approval.featureCount,
+  };
+  const candidate: SandreGeometryNormalizationCandidate = {
+    ...feature,
+    relativeAreaDelta: 4.327937393518178e-8,
+    absoluteGeodesicAreaDeltaSquareMeters: 20.807422280311584,
+  };
+
+  it('approves every exact department 11 source fixture within both bounds', () => {
+    expect(approval.features.map((item) => item.codeSandre)).toEqual([
+      '3575',
+      '3579',
+      '3586',
+      '3592',
+      '3951',
+      '3956',
+      '3958',
+      '3961',
+    ]);
+    for (const approvedFeature of approval.features) {
+      expect(
+        findSandreGeometryNormalizationApproval(context, {
+          ...approvedFeature,
+          relativeAreaDelta: approvedFeature.maxRelativeAreaDelta,
+          absoluteGeodesicAreaDeltaSquareMeters:
+            approvedFeature.maxAbsoluteGeodesicAreaDeltaSquareMeters,
+        }),
+      ).toBe(approval);
+    }
+  });
+
+  it.each<
+    [
+      string,
+      {
+        context?: SandreGeometryNormalizationContext;
+        candidate?: SandreGeometryNormalizationCandidate;
+      },
+    ]
+  >([
+    ['department', { context: { ...context, departmentCode: '12' } }],
+    ['snapshot', { context: { ...context, snapshotHash: '0'.repeat(64) } }],
+    ['source date', { context: { ...context, sourceUpdatedAt: '2026-08-14' } }],
+    ['feature count', { context: { ...context, featureCount: 55 } }],
+    ['gid', { candidate: { ...candidate, gid: 9999 } }],
+    ['payload', { candidate: { ...candidate, payloadHash: '0'.repeat(64) } }],
+    [
+      'raw geometry',
+      { candidate: { ...candidate, rawGeometryHash: '0'.repeat(64) } },
+    ],
+    [
+      'normalized geometry',
+      { candidate: { ...candidate, normalizedGeometryHash: '0'.repeat(64) } },
+    ],
+    [
+      'normalized geometry type',
+      { candidate: { ...candidate, normalizedGeometryType: 'POLYGON' } },
+    ],
+    ['raw parts', { candidate: { ...candidate, rawParts: 281 } }],
+    ['normalized parts', { candidate: { ...candidate, normalizedParts: 336 } }],
+    ['raw points', { candidate: { ...candidate, rawPoints: 9113 } }],
+    [
+      'normalized points',
+      { candidate: { ...candidate, normalizedPoints: 8840 } },
+    ],
+    [
+      'relative bound',
+      {
+        candidate: {
+          ...candidate,
+          relativeAreaDelta: feature.maxRelativeAreaDelta + 1e-12,
+        },
+      },
+    ],
+    [
+      'absolute bound',
+      {
+        candidate: {
+          ...candidate,
+          absoluteGeodesicAreaDeltaSquareMeters:
+            feature.maxAbsoluteGeodesicAreaDeltaSquareMeters + 0.001,
+        },
+      },
+    ],
+  ])('rejects %s drift', (_label, overrides) => {
+    expect(
+      findSandreGeometryNormalizationApproval(
+        overrides.context ?? context,
+        overrides.candidate ?? candidate,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-geometry-approvals.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-geometry-approvals.ts
@@ -1,0 +1,253 @@
+export interface SandreGeometryNormalizationContext {
+  departmentCode: string;
+  snapshotHash: string;
+  sourceUpdatedAt: string | null;
+  featureCount: number;
+}
+
+export interface SandreGeometryNormalizationCandidate {
+  codeSandre: string;
+  gid: number;
+  payloadHash: string;
+  rawGeometryHash: string;
+  normalizedGeometryHash: string;
+  rawGeometryType: string;
+  normalizedGeometryType: string;
+  rawParts: number;
+  normalizedParts: number;
+  rawPoints: number;
+  normalizedPoints: number;
+  relativeAreaDelta: number;
+  absoluteGeodesicAreaDeltaSquareMeters: number;
+}
+
+export interface SandreGeometryNormalizationApproval {
+  id: string;
+  departmentCode: string;
+  snapshotHash: string;
+  sourceUpdatedAt: string;
+  featureCount: number;
+  maxRelativeAreaDelta: number;
+  maxAbsoluteGeodesicAreaDeltaSquareMeters: number;
+  features: Array<{
+    codeSandre: string;
+    gid: number;
+    payloadHash: string;
+    rawGeometryHash: string;
+    normalizedGeometryHash: string;
+    rawGeometryType: 'MULTIPOLYGON';
+    normalizedGeometryType: 'MULTIPOLYGON';
+    rawParts: number;
+    normalizedParts: number;
+    rawPoints: number;
+    normalizedPoints: number;
+    maxRelativeAreaDelta: number;
+    maxAbsoluteGeodesicAreaDeltaSquareMeters: number;
+  }>;
+}
+
+// These exceptions are immutable source fixtures. Any upstream payload or raw
+// geometry change falls back to the strict global normalization threshold.
+export const SANDRE_GEOMETRY_NORMALIZATION_APPROVALS: readonly SandreGeometryNormalizationApproval[] =
+  [
+    {
+      id: '2026-08-15-department-11-invalid-source-geometries',
+      departmentCode: '11',
+      snapshotHash:
+        '7836f3211bee2b02bb1af6624cc9b25faec0126f8c80a58cc555962479da68d9',
+      sourceUpdatedAt: '2026-08-13',
+      featureCount: 54,
+      maxRelativeAreaDelta: 5e-8,
+      maxAbsoluteGeodesicAreaDeltaSquareMeters: 25,
+      features: [
+        {
+          codeSandre: '3575',
+          gid: 3575,
+          payloadHash:
+            'c5848889f0306c43b2b89760e6c666b8f34d539f789e648e6783c674ab6b04d5',
+          rawGeometryHash:
+            'da24a4b3f357b39ac0c8deddddffd0680df3a3e47a86164551d3b12154a276b8',
+          normalizedGeometryHash:
+            'b27e1f52fa9b14efbbf56f96a141befd4dae2d3861ec1d5055bc0aca13e04ce3',
+          rawGeometryType: 'MULTIPOLYGON',
+          normalizedGeometryType: 'MULTIPOLYGON',
+          rawParts: 37,
+          normalizedParts: 43,
+          rawPoints: 8785,
+          normalizedPoints: 8631,
+          maxRelativeAreaDelta: 3.6e-9,
+          maxAbsoluteGeodesicAreaDeltaSquareMeters: 1.8,
+        },
+        {
+          codeSandre: '3579',
+          gid: 3579,
+          payloadHash:
+            '6d59218028d254f82d6d66d95e346ddb7d14c680d39ca8dd2e904c9509570897',
+          rawGeometryHash:
+            '50114a1b42924b6e510278ae09d42f091f7102c9103450f301d7cb97b06e786b',
+          normalizedGeometryHash:
+            '1c577366664f859ff840507d41670ce6fabed2cd573804113bd0747b8341c035',
+          rawGeometryType: 'MULTIPOLYGON',
+          normalizedGeometryType: 'MULTIPOLYGON',
+          rawParts: 33,
+          normalizedParts: 38,
+          rawPoints: 8353,
+          normalizedPoints: 8273,
+          maxRelativeAreaDelta: 2.4e-9,
+          maxAbsoluteGeodesicAreaDeltaSquareMeters: 1.2,
+        },
+        {
+          codeSandre: '3586',
+          gid: 3586,
+          payloadHash:
+            'c586c36b73ba27b045f1ea20596e85ca13e7df579dacde678499b67e1b9c8400',
+          rawGeometryHash:
+            '8bf2afa53e7b0f5d0d0b38f2dff5c734cadbe6675fcb54beedd3653ecbf68669',
+          normalizedGeometryHash:
+            '97e7b260b02179e256b593dd256f52b350844077951c60c8d68bdef0f2c3c586',
+          rawGeometryType: 'MULTIPOLYGON',
+          normalizedGeometryType: 'MULTIPOLYGON',
+          rawParts: 160,
+          normalizedParts: 163,
+          rawPoints: 4746,
+          normalizedPoints: 4674,
+          maxRelativeAreaDelta: 7.8e-9,
+          maxAbsoluteGeodesicAreaDeltaSquareMeters: 4,
+        },
+        {
+          codeSandre: '3592',
+          gid: 3592,
+          payloadHash:
+            '2d21b1bb96e2f29fbfde912d9d579410fc28ea7acd5c505a7c170c72bca64701',
+          rawGeometryHash:
+            '53e69a81415d4c4340d09df6f7edc53086171a82626cdcf99407623d56d93bcd',
+          normalizedGeometryHash:
+            '4cde431879147a41f48b864acf10002c8db7f47c56a3ae34583bfbb706747298',
+          rawGeometryType: 'MULTIPOLYGON',
+          normalizedGeometryType: 'MULTIPOLYGON',
+          rawParts: 2,
+          normalizedParts: 3,
+          rawPoints: 310,
+          normalizedPoints: 304,
+          maxRelativeAreaDelta: 6e-9,
+          maxAbsoluteGeodesicAreaDeltaSquareMeters: 0.04,
+        },
+        {
+          codeSandre: '3951',
+          gid: 3951,
+          payloadHash:
+            'b96d6fec16b4bbb19d4c1fc8ef885eedcd5ebf68c59834a8db8b555152b4b040',
+          rawGeometryHash:
+            '3fc3ea162076191c17946dbb1fcc404804ba0a1b5535b64e06bd53034c590372',
+          normalizedGeometryHash:
+            '9faef154c805adc07691b4f6068f23f7fafc426e60e33c743152ac4d1cc056c0',
+          rawGeometryType: 'MULTIPOLYGON',
+          normalizedGeometryType: 'MULTIPOLYGON',
+          rawParts: 44,
+          normalizedParts: 49,
+          rawPoints: 8076,
+          normalizedPoints: 7990,
+          maxRelativeAreaDelta: 2.2e-9,
+          maxAbsoluteGeodesicAreaDeltaSquareMeters: 1.1,
+        },
+        {
+          codeSandre: '3956',
+          gid: 3956,
+          payloadHash:
+            'a064e1ee0186cfae8642ecb06bf43696392be6f10fada1a77544d6951a58c755',
+          rawGeometryHash:
+            'dc25ab72fa68f8746e82c58a3ef09795a41511e9c6a90d6d836f0176a86c130f',
+          normalizedGeometryHash:
+            '6c82f58706fbe5d4efc142db4f4b01bc44276e94848d59a34d5a7c7c6789d0ad',
+          rawGeometryType: 'MULTIPOLYGON',
+          normalizedGeometryType: 'MULTIPOLYGON',
+          rawParts: 95,
+          normalizedParts: 77,
+          rawPoints: 4194,
+          normalizedPoints: 3975,
+          maxRelativeAreaDelta: 4.6e-9,
+          maxAbsoluteGeodesicAreaDeltaSquareMeters: 2.4,
+        },
+        {
+          codeSandre: '3958',
+          gid: 3958,
+          payloadHash:
+            '366bdd85b8189d03d9d31841b0fd139300818113029920c8ea051f575d76c00b',
+          rawGeometryHash:
+            '7e2445b7ca90fc7bfe75a74bf22fcb6912ef90100b99675e8aa9e34ece7bec9e',
+          normalizedGeometryHash:
+            '74b340c0cfd8779ee9136c074e4e1e659325a519cca20f1209f784ec170ce77f',
+          rawGeometryType: 'MULTIPOLYGON',
+          normalizedGeometryType: 'MULTIPOLYGON',
+          rawParts: 280,
+          normalizedParts: 335,
+          rawPoints: 9112,
+          normalizedPoints: 8839,
+          maxRelativeAreaDelta: 4.6e-8,
+          maxAbsoluteGeodesicAreaDeltaSquareMeters: 22,
+        },
+        {
+          codeSandre: '3961',
+          gid: 3961,
+          payloadHash:
+            'dcef39950c9246e7ebe5bd9450761e7a2ecaf2c3f47624dcb067ce317133830e',
+          rawGeometryHash:
+            '8bb2ada29f08faecc2baa57dd4ffb7a29dc912b77351679df5d9e09912566888',
+          normalizedGeometryHash:
+            '02bd15b44cbd554253a3e62d51f98fdc9fc36562f1e63378c2b0b8c58a15e815',
+          rawGeometryType: 'MULTIPOLYGON',
+          normalizedGeometryType: 'MULTIPOLYGON',
+          rawParts: 17,
+          normalizedParts: 19,
+          rawPoints: 3576,
+          normalizedPoints: 3512,
+          maxRelativeAreaDelta: 9e-9,
+          maxAbsoluteGeodesicAreaDeltaSquareMeters: 0.15,
+        },
+      ],
+    },
+  ];
+
+export function findSandreGeometryNormalizationApproval(
+  context: SandreGeometryNormalizationContext | undefined,
+  candidate: SandreGeometryNormalizationCandidate,
+): SandreGeometryNormalizationApproval | null {
+  if (!context) {
+    return null;
+  }
+  for (const approval of SANDRE_GEOMETRY_NORMALIZATION_APPROVALS) {
+    if (
+      approval.departmentCode !== context.departmentCode ||
+      approval.snapshotHash !== context.snapshotHash ||
+      approval.sourceUpdatedAt !== context.sourceUpdatedAt ||
+      approval.featureCount !== context.featureCount ||
+      candidate.relativeAreaDelta > approval.maxRelativeAreaDelta ||
+      candidate.absoluteGeodesicAreaDeltaSquareMeters >
+        approval.maxAbsoluteGeodesicAreaDeltaSquareMeters
+    ) {
+      continue;
+    }
+    const feature = approval.features.find(
+      (item) => item.codeSandre === candidate.codeSandre,
+    );
+    if (
+      feature &&
+      candidate.relativeAreaDelta <= feature.maxRelativeAreaDelta &&
+      candidate.absoluteGeodesicAreaDeltaSquareMeters <=
+        feature.maxAbsoluteGeodesicAreaDeltaSquareMeters &&
+      feature.gid === candidate.gid &&
+      feature.payloadHash === candidate.payloadHash &&
+      feature.rawGeometryHash === candidate.rawGeometryHash &&
+      feature.normalizedGeometryHash === candidate.normalizedGeometryHash &&
+      feature.rawGeometryType === candidate.rawGeometryType &&
+      feature.normalizedGeometryType === candidate.normalizedGeometryType &&
+      feature.rawParts === candidate.rawParts &&
+      feature.normalizedParts === candidate.normalizedParts &&
+      feature.rawPoints === candidate.rawPoints &&
+      feature.normalizedPoints === candidate.normalizedPoints
+    ) {
+      return approval;
+    }
+  }
+  return null;
+}

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-geometry.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-geometry.spec.ts
@@ -2,6 +2,7 @@ import {
   normalizeSandreZoneGeometries,
   SANDRE_GEOMETRY_MAX_RELATIVE_AREA_DELTA,
 } from './sandre-zone-geometry';
+import * as geometryApprovals from './sandre-zone-geometry-approvals';
 
 const feature = (codeSandre: string, geometry: any) =>
   ({ codeSandre, geometry }) as any;
@@ -37,6 +38,9 @@ describe('Sandre geometry normalization', () => {
           raw_area: '0.5',
           normalized_area: '0.5',
           relative_area_delta: '0',
+          raw_geodesic_area: '5000000',
+          normalized_geodesic_area: '5000000',
+          absolute_geodesic_area_delta: '0',
           bbox_unchanged: true,
           normalized_valid: true,
         },
@@ -85,6 +89,9 @@ describe('Sandre geometry normalization', () => {
           raw_area: '10',
           normalized_area: '10.0000000001',
           relative_area_delta: '1e-11',
+          raw_geodesic_area: '100000000',
+          normalized_geodesic_area: '100000000.1',
+          absolute_geodesic_area_delta: '0.1',
           bbox_unchanged: true,
           normalized_valid: true,
         },
@@ -102,6 +109,73 @@ describe('Sandre geometry normalization', () => {
         relativeAreaDelta: 1e-11,
       }),
     );
+  });
+
+  it('accepts an over-threshold repair only with a source-scoped approval', async () => {
+    const repairedGeometry = {
+      type: 'MultiPolygon',
+      coordinates: [validGeometry.coordinates],
+    };
+    const approval =
+      geometryApprovals.SANDRE_GEOMETRY_NORMALIZATION_APPROVALS[0];
+    const approvalSpy = jest
+      .spyOn(geometryApprovals, 'findSandreGeometryNormalizationApproval')
+      .mockReturnValue(approval);
+    const executor = {
+      query: jest.fn().mockResolvedValue([
+        {
+          ordinal: 1,
+          code: 'APPROVED',
+          geometry: repairedGeometry,
+          raw_valid: false,
+          invalid_reason: 'Self-intersection',
+          raw_geometry_type: 'MULTIPOLYGON',
+          normalized_geometry_type: 'MULTIPOLYGON',
+          raw_parts: 2,
+          normalized_parts: 3,
+          raw_points: 10,
+          normalized_points: 11,
+          raw_area: '10',
+          normalized_area: '10.00000002',
+          relative_area_delta: '2e-9',
+          raw_geodesic_area: '100000000',
+          normalized_geodesic_area: '100000001',
+          absolute_geodesic_area_delta: '1',
+          bbox_unchanged: true,
+          normalized_valid: true,
+        },
+      ]),
+    };
+    const context = {
+      departmentCode: '11',
+      snapshotHash: approval.snapshotHash,
+      sourceUpdatedAt: approval.sourceUpdatedAt,
+      featureCount: approval.featureCount,
+    };
+
+    const result = await normalizeSandreZoneGeometries(
+      executor,
+      [feature('APPROVED', validGeometry)],
+      context,
+    );
+
+    expect(result.features[0].geometry).toBe(repairedGeometry);
+    expect(result.audits.get('APPROVED')).toEqual(
+      expect.objectContaining({
+        relativeAreaDelta: 2e-9,
+        absoluteGeodesicAreaDeltaSquareMeters: 1,
+        normalizationApprovalId: approval.id,
+      }),
+    );
+    expect(approvalSpy).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({
+        codeSandre: 'APPROVED',
+        relativeAreaDelta: 2e-9,
+        absoluteGeodesicAreaDeltaSquareMeters: 1,
+      }),
+    );
+    approvalSpy.mockRestore();
   });
 
   it.each([
@@ -132,6 +206,9 @@ describe('Sandre geometry normalization', () => {
           normalized_points: 6,
           raw_area: '1',
           normalized_area: '1',
+          raw_geodesic_area: '10000000',
+          normalized_geodesic_area: '10000000',
+          absolute_geodesic_area_delta: '0',
           normalized_valid: true,
           ...overrides,
         },

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-geometry.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-geometry.ts
@@ -1,5 +1,9 @@
 import { createHash } from 'crypto';
 import { SandreZoneFeature } from './sandre-zone-sync';
+import {
+  findSandreGeometryNormalizationApproval,
+  SandreGeometryNormalizationContext,
+} from './sandre-zone-geometry-approvals';
 
 export const SANDRE_GEOMETRY_MAX_RELATIVE_AREA_DELTA = 1e-9;
 
@@ -18,6 +22,10 @@ export interface SandreGeometryAudit {
   rawArea: number;
   normalizedArea: number;
   relativeAreaDelta: number;
+  rawGeodesicAreaSquareMeters: number;
+  normalizedGeodesicAreaSquareMeters: number;
+  absoluteGeodesicAreaDeltaSquareMeters: number;
+  normalizationApprovalId: string | null;
 }
 
 export interface SandreGeometryQueryExecutor {
@@ -27,6 +35,7 @@ export interface SandreGeometryQueryExecutor {
 export async function normalizeSandreZoneGeometries(
   executor: SandreGeometryQueryExecutor,
   features: SandreZoneFeature[],
+  context?: SandreGeometryNormalizationContext,
 ): Promise<{
   features: SandreZoneFeature[];
   audits: Map<string, SandreGeometryAudit>;
@@ -75,7 +84,9 @@ export async function normalizeSandreZoneGeometries(
         SELECT
           *,
           ST_Area(raw_geom) AS raw_area,
-          ST_Area(normalized_geom) AS normalized_area
+          ST_Area(normalized_geom) AS normalized_area,
+          ST_Area(raw_geom::geography) AS raw_geodesic_area,
+          ST_Area(normalized_geom::geography) AS normalized_geodesic_area
         FROM repaired
       )
       SELECT
@@ -97,6 +108,11 @@ export async function normalizeSandreZoneGeometries(
           ELSE abs(normalized_area - raw_area)
             / GREATEST(abs(raw_area), abs(normalized_area))
         END::text AS relative_area_delta,
+        raw_geodesic_area::text AS raw_geodesic_area,
+        normalized_geodesic_area::text AS normalized_geodesic_area,
+        abs(
+          normalized_geodesic_area - raw_geodesic_area
+        )::text AS absolute_geodesic_area_delta,
         (
           ST_XMin(Box3D(normalized_geom)) = ST_XMin(Box3D(raw_geom))
           AND ST_XMax(Box3D(normalized_geom)) = ST_XMax(Box3D(raw_geom))
@@ -140,18 +156,51 @@ export async function normalizeSandreZoneGeometries(
       throw new Error('Sandre geometry normalization order changed');
     }
     const relativeAreaDelta = Number(row.relative_area_delta);
+    const rawGeodesicAreaSquareMeters = Number(row.raw_geodesic_area);
+    const normalizedGeodesicAreaSquareMeters = Number(
+      row.normalized_geodesic_area,
+    );
+    const absoluteGeodesicAreaDeltaSquareMeters = Number(
+      row.absolute_geodesic_area_delta,
+    );
+    const rawGeometryHash = hashGeometry(feature.geometry);
+    const normalizedGeometryHash = hashGeometry(
+      row.raw_valid === true ? feature.geometry : row.geometry,
+    );
+    const approval =
+      relativeAreaDelta > SANDRE_GEOMETRY_MAX_RELATIVE_AREA_DELTA
+        ? findSandreGeometryNormalizationApproval(context, {
+            codeSandre: feature.codeSandre,
+            gid: feature.gid,
+            payloadHash: feature.payloadHash,
+            rawGeometryHash,
+            normalizedGeometryHash,
+            rawGeometryType: String(row.raw_geometry_type),
+            normalizedGeometryType: String(row.normalized_geometry_type),
+            rawParts: Number(row.raw_parts),
+            normalizedParts: Number(row.normalized_parts),
+            rawPoints: Number(row.raw_points),
+            normalizedPoints: Number(row.normalized_points),
+            relativeAreaDelta,
+            absoluteGeodesicAreaDeltaSquareMeters,
+          })
+        : null;
     if (
       row.normalized_valid !== true ||
       row.bbox_unchanged !== true ||
       !row.geometry ||
       !Number.isFinite(relativeAreaDelta) ||
-      relativeAreaDelta > SANDRE_GEOMETRY_MAX_RELATIVE_AREA_DELTA
+      !Number.isFinite(rawGeodesicAreaSquareMeters) ||
+      !Number.isFinite(normalizedGeodesicAreaSquareMeters) ||
+      !Number.isFinite(absoluteGeodesicAreaDeltaSquareMeters) ||
+      (relativeAreaDelta > SANDRE_GEOMETRY_MAX_RELATIVE_AREA_DELTA && !approval)
     ) {
       throw new Error(
         `Unsafe Sandre geometry normalization for zone ${feature.codeSandre}: ` +
           `valid=${row.normalized_valid === true}, ` +
           `bboxUnchanged=${row.bbox_unchanged === true}, ` +
-          `areaDelta=${relativeAreaDelta}`,
+          `areaDelta=${relativeAreaDelta}, ` +
+          `absoluteGeodesicAreaDeltaSquareMeters=${absoluteGeodesicAreaDeltaSquareMeters}`,
       );
     }
 
@@ -165,8 +214,8 @@ export async function normalizeSandreZoneGeometries(
       codeSandre: feature.codeSandre,
       normalized: row.raw_valid !== true,
       invalidReason: String(row.invalid_reason),
-      rawGeometryHash: hashGeometry(feature.geometry),
-      normalizedGeometryHash: hashGeometry(normalizedGeometry),
+      rawGeometryHash,
+      normalizedGeometryHash,
       rawGeometryType: String(row.raw_geometry_type),
       normalizedGeometryType: String(row.normalized_geometry_type),
       rawParts: Number(row.raw_parts),
@@ -176,6 +225,10 @@ export async function normalizeSandreZoneGeometries(
       rawArea: Number(row.raw_area),
       normalizedArea: Number(row.normalized_area),
       relativeAreaDelta,
+      rawGeodesicAreaSquareMeters,
+      normalizedGeodesicAreaSquareMeters,
+      absoluteGeodesicAreaDeltaSquareMeters,
+      normalizationApprovalId: approval?.id ?? null,
     };
     normalizedFeatures.push(normalizedFeature);
     audits.set(feature.codeSandre, audit);

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.spec.ts
@@ -16,6 +16,10 @@ describe('audited Sandre reconciliation plans', () => {
     __dirname,
     '../scripts/sandre-reconciliation-plans/2026-08-15-prod-sandre-unblock.json',
   );
+  const auditBlockersPlanPath = resolve(
+    __dirname,
+    '../scripts/sandre-reconciliation-plans/2026-08-15-prod-sandre-audit-blockers.json',
+  );
 
   it('signs every operational action and generic sync expectation', () => {
     const serializedPlan = readFileSync(planPath, 'utf8');
@@ -74,6 +78,51 @@ describe('audited Sandre reconciliation plans', () => {
     );
   });
 
+  it('keeps the follow-up audit blockers in a separate exact operation', () => {
+    const serializedPlan = readFileSync(auditBlockersPlanPath, 'utf8');
+    const plan = parseSandreReconciliationPlan(JSON.parse(serializedPlan));
+
+    expect(plan.operationId).toBe('2026-08-15-prod-sandre-audit-blockers');
+    expect(plan.syncExpectations).toEqual([
+      {
+        departmentCode: '11',
+        officialCodes: [
+          '3575',
+          '3579',
+          '3586',
+          '3592',
+          '3951',
+          '3956',
+          '3958',
+          '3961',
+        ],
+        resolution: 'geometry_normalization',
+      },
+    ]);
+    expect(plan.actions).toEqual([
+      expect.objectContaining({
+        strategy: 'canonicalize_duplicate',
+        departmentCode: '49',
+        zoneType: 'SOU',
+        sourceZoneId: 16677,
+        targetZoneId: 9708,
+        expectedSourceCode: '52_49_15',
+        expectedSandreGid: 409,
+        officialCode: '301',
+        requiredSourceBusinessReferenceCount: 0,
+        restrictionConflictPolicy: expect.objectContaining({
+          expectedCount: 0,
+          expectedFingerprint:
+            '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945',
+        }),
+      }),
+    ]);
+    expect(reconciliationPlanFingerprint(plan)).toMatch(/^[a-f0-9]{64}$/);
+    expect(serializedPlan).not.toMatch(
+      /DATABASE_|API_SANDRE|PASSWORD|SECRET|postgres(?:ql)?:\/\//i,
+    );
+  });
+
   it('requires an exact restriction conflict policy for canonical duplicates', () => {
     const conflict = canonicalConflict();
     const action = canonicalAction([conflict]);
@@ -104,6 +153,34 @@ describe('audited Sandre reconciliation plans', () => {
         ],
       }),
     ).toThrow('Invalid canonical Sandre duplicate action');
+  });
+
+  it('rejects the retired plan-level partition replication path', () => {
+    const policy = {
+      mode: 'replicate_exact_to_all_targets',
+      requiredParentStatuses: ['a_venir', 'publie'],
+      expectedSourceCount: 2,
+      expectedSourceFingerprint: 'a'.repeat(64),
+      expectedTargetCollisionCount: 0,
+      expectedTargetCollisionFingerprint: fingerprint([]),
+    };
+    expect(() =>
+      parseSandreReconciliationPlan({
+        schemaVersion: 1,
+        operationId: 'partition-restriction-policy',
+        description: 'test',
+        actions: [
+          {
+            strategy: 'replace_partition_1ton',
+            departmentCode: '85',
+            zoneType: 'SUP',
+            sourceZoneId: 10582,
+            targetZoneIds: [20001, 20002],
+            restrictionReplicationPolicy: policy,
+          },
+        ],
+      }),
+    ).toThrow('Legacy partition evidence is not supported');
   });
 
   it('fails closed when canonical restriction conflicts drift', () => {
@@ -421,6 +498,9 @@ function geometryAuditRow(overrides: Record<string, unknown>): any {
     raw_area: '1',
     normalized_area: '1',
     relative_area_delta: '0',
+    raw_geodesic_area: '10000000',
+    normalized_geodesic_area: '10000000',
+    absolute_geodesic_area_delta: '0',
     bbox_unchanged: true,
     normalized_valid: true,
     ...overrides,

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation-actions.ts
@@ -41,6 +41,7 @@ export interface CanonicalizeDuplicateAction extends SandreReconciliationActionB
   targetZoneId: number;
   expectedSandreGid: number;
   officialCode: string;
+  requiredSourceBusinessReferenceCount?: number;
   restrictionConflictPolicy: {
     mode: 'prefer_source';
     expectedCount: number;
@@ -349,6 +350,12 @@ export async function auditSandreSyncExpectations(
       const normalized = await normalizeSandreZoneGeometries(
         executor,
         features as any,
+        {
+          departmentCode: snapshot.departmentCode,
+          snapshotHash: snapshot.snapshotHash,
+          sourceUpdatedAt: snapshot.sourceUpdatedAt,
+          featureCount: snapshot.featureCount,
+        },
       );
       const featureEvidence = features.map((feature) => {
         const geometry = normalized.audits.get(feature.codeSandre);
@@ -794,6 +801,15 @@ async function auditAction(
 
   let restrictionConflicts: SandreActionAudit['restrictionConflicts'] = null;
   if (action.strategy === 'canonicalize_duplicate') {
+    if (
+      action.requiredSourceBusinessReferenceCount !== undefined &&
+      Number(source.allBusinessReferences) !==
+        action.requiredSourceBusinessReferenceCount
+    ) {
+      throw new Error(
+        `Duplicate canonicalization source references changed for ${action.sourceZoneId}`,
+      );
+    }
     if (
       (!alreadyApplied &&
         Number(source.idSandre) !== action.expectedSandreGid) ||
@@ -1472,6 +1488,15 @@ function actionIsAlreadyApplied(
     return (
       source.disabled === true &&
       source.idSandre === null &&
+      source.codeSandre === null &&
+      source.statutSandre === null &&
+      source.dateMajSandre === null &&
+      source.numeroVersionSandre === null &&
+      (source.codesAlternatifs === null ||
+        (Array.isArray(source.codesAlternatifs) &&
+          source.codesAlternatifs.length === 0)) &&
+      source.sandrePayloadHash === null &&
+      source.sandreProvenance === 'legacy_unverified' &&
       Number(source.allBusinessReferences) === 0 &&
       references.aliases === 0
     );
@@ -1528,7 +1553,10 @@ function parseAction(value: unknown): SandreReconciliationAction {
       typeof action.officialCode !== 'string' ||
       action.officialCode.length === 0 ||
       action.officialCode.length > 32 ||
-      !isCanonicalRestrictionConflictPolicy(action.restrictionConflictPolicy))
+      !isCanonicalRestrictionConflictPolicy(action.restrictionConflictPolicy) ||
+      (action.requiredSourceBusinessReferenceCount !== undefined &&
+        (!Number.isInteger(action.requiredSourceBusinessReferenceCount) ||
+          Number(action.requiredSourceBusinessReferenceCount) < 0)))
   ) {
     throw new Error('Invalid canonical Sandre duplicate action');
   }
@@ -1539,6 +1567,12 @@ function parseAction(value: unknown): SandreReconciliationAction {
     throw new Error(
       'Restriction conflict resolution is only valid for canonical duplicates',
     );
+  }
+  if (
+    action.restrictionReplicationPolicy !== undefined ||
+    action.officialSplitEvidence !== undefined
+  ) {
+    throw new Error('Legacy partition evidence is not supported');
   }
   return action as unknown as SandreReconciliationAction;
 }

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-reconciliation.ts
@@ -5,6 +5,11 @@ import { csv2json } from 'json-2-csv';
 export const SANDRE_GENEALOGY_METADATA_URL =
   'https://www.sandre.eaufrance.fr/atlas/srv/api/records/0391a8b8-c850-45c7-a372-1f95bd204159/formatters/xml';
 
+export const SANDRE_GENEALOGY_REQUEST_HEADERS = {
+  accept: 'application/xml,text/xml,text/csv,text/html;q=0.9',
+  'accept-language': 'fr',
+} as const;
+
 const SANDRE_GENEALOGY_RESOURCE_NAME =
   "Télécharger la généalogie des zones d'alerte sécheresse";
 

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-sync-approvals.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-sync-approvals.spec.ts
@@ -1,0 +1,79 @@
+import {
+  findSandreApprovedSyncSnapshot,
+  SANDRE_APPROVED_SYNC_SNAPSHOTS,
+} from './sandre-zone-sync-approvals';
+
+describe('exact Sandre sync approvals', () => {
+  it('pins the complete department 24 and 85 mapping cardinalities', () => {
+    const department24 = SANDRE_APPROVED_SYNC_SNAPSHOTS.find(
+      (approval) => approval.departmentCode === '24',
+    )!;
+    const department85 = SANDRE_APPROVED_SYNC_SNAPSHOTS.find(
+      (approval) => approval.departmentCode === '85',
+    )!;
+
+    expect(department24.mappings).toHaveLength(54);
+    expect(
+      department24.mappings.flatMap((mapping) => mapping.targetCodes),
+    ).toHaveLength(55);
+    expect(
+      department24.mappings.find((mapping) => mapping.sourceCode === '1028'),
+    ).toEqual(
+      expect.objectContaining({
+        sourceZoneId: 12097,
+        targetCodes: ['4116', '4117'],
+        requireTopologicalEquality: false,
+      }),
+    );
+    expect(
+      department24.mappings
+        .filter((mapping) => mapping.targetCodes.length === 1)
+        .every((mapping) => mapping.requireTopologicalEquality),
+    ).toBe(true);
+
+    expect(department85.mappings).toEqual([
+      expect.objectContaining({
+        sourceCode: '355',
+        sourceZoneId: 10582,
+        targetCodes: ['3947', '3948'],
+      }),
+    ]);
+    expect(department85.mdmRecords.map((record) => record.codeSandre)).toEqual([
+      '355',
+      '3947',
+      '3948',
+    ]);
+  });
+
+  it('does not approve a snapshot with any source seal drift', () => {
+    const department85 = SANDRE_APPROVED_SYNC_SNAPSHOTS.find(
+      (approval) => approval.departmentCode === '85',
+    )!;
+    const emptySnapshot = {
+      features: [],
+      featureCount: department85.featureCount,
+      sourceUpdatedAt: department85.sourceUpdatedAt,
+      snapshotHash: `${department85.snapshotHash.slice(0, -1)}0`,
+    };
+    expect(findSandreApprovedSyncSnapshot('85', emptySnapshot)).toBeNull();
+  });
+
+  it('keeps every configured geometry threshold in the strict range', () => {
+    for (const approval of SANDRE_APPROVED_SYNC_SNAPSHOTS) {
+      for (const mapping of approval.mappings) {
+        expect(Object.values(mapping.minimumGeometry)).toEqual(
+          expect.arrayContaining([
+            expect.any(Number),
+            expect.any(Number),
+            expect.any(Number),
+          ]),
+        );
+        expect(
+          Object.values(mapping.minimumGeometry).every(
+            (threshold) => threshold >= 0.9999 && threshold <= 1,
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-sync-approvals.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-sync-approvals.ts
@@ -1,0 +1,701 @@
+import { fingerprint } from './sandre-zone-reconciliation';
+import { SandreZoneFeature, SandreZoneSnapshot } from './sandre-zone-sync';
+
+export interface SandreApprovedSyncMapping {
+  sourceCode: string;
+  sourceZoneId: number;
+  targetCodes: string[];
+  requireTopologicalEquality: boolean;
+  effectiveDate: string | null;
+  expectedGeometry: {
+    sourceGeometryHash: string;
+    targetGeometryHashes: string[];
+    unionGeometryHash: string;
+    sourceCoverage: number;
+    targetCoverage: number;
+    iou: number;
+  } | null;
+  minimumGeometry: {
+    sourceCoverage: number;
+    targetCoverage: number;
+    iou: number;
+  };
+}
+
+export interface SandreApprovedGeometryEvidence {
+  sourceGeometryHash: string;
+  targetGeometryHashes: string[];
+  unionGeometryHash: string;
+  sourceCoverage: number;
+  targetCoverage: number;
+  iou: number;
+  pairwiseOverlapRatio: number;
+  topologicallyEqual: boolean;
+  sourceValid: boolean;
+  targetsValid: boolean;
+  sourceSrid: number;
+  targetsSrid: number;
+  sourceType: string;
+  targetType: string;
+}
+
+export interface SandreApprovedGeometryQueryExecutor {
+  query(query: string, parameters?: any[]): Promise<any[]>;
+}
+
+export interface SandreMdmZoneExpectation {
+  codeSandre: string;
+  projectionSha256: string;
+  requiredEvolution: {
+    typeNid: string;
+    date: string;
+    comment: string;
+  } | null;
+}
+
+export interface SandreApprovedSyncSnapshot {
+  approvalId: string;
+  departmentCode: string;
+  snapshotHash: string;
+  sourceUpdatedAt: string;
+  featureCount: number;
+  featureEvidenceFingerprint: string;
+  expectedSourceCount: number;
+  expectedTargetCount: number;
+  mappings: SandreApprovedSyncMapping[];
+  mdmRecords: SandreMdmZoneExpectation[];
+  mdmNomenclature: SandreMdmNomenclatureExpectation | null;
+}
+
+export interface SandreMdmNomenclatureExpectation {
+  nid: string;
+  nomenclatureCode: string;
+  title: string;
+  code: string;
+  mnemonic: string;
+  projectionSha256: string;
+}
+
+const DEPARTMENT_24_MAPPINGS: SandreApprovedSyncMapping[] = [
+  partitionMapping('1028', 12097, ['4116', '4117'], '2026-08-05', {
+    sourceGeometryHash: '1dfe5df2047067b2403c5275ca269945',
+    targetGeometryHashes: [
+      '93f4317d20505889d136a35ff5d8015f',
+      'd21eee234aa3e64316c17775cc6f1f47',
+    ],
+    unionGeometryHash: '28ce8d6311c791c0cf3eebb696e1d59f',
+    sourceCoverage: 0.9999922468432514,
+    targetCoverage: 0.9999929950328335,
+    iou: 0.9999852419847116,
+  }),
+  mapping('1029', 12098, ['4077']),
+  mapping('1030', 12099, ['4080']),
+  mapping('1032', 12102, ['4065']),
+  mapping('1033', 12104, ['4115']),
+  mapping('1034', 12107, ['4066']),
+  mapping('1035', 12110, ['4112']),
+  mapping('1037', 12112, ['4111']),
+  mapping('1040', 12115, ['4090']),
+  mapping('1041', 12116, ['4109']),
+  mapping('1045', 12124, ['4071']),
+  mapping('1048', 12131, ['4072']),
+  mapping('1049', 12132, ['4073']),
+  mapping('1050', 12135, ['4074']),
+  mapping('1051', 12136, ['4075']),
+  mapping('1052', 12137, ['4110']),
+  mapping('1053', 12139, ['4107']),
+  mapping('1054', 12140, ['4108']),
+  mapping('1531', 12111, ['4098']),
+  mapping('1540', 12092, ['4063']),
+  mapping('1541', 12093, ['4083']),
+  mapping('1542', 12094, ['4064']),
+  mapping('1543', 12095, ['4079']),
+  mapping('1545', 12096, ['4069']),
+  mapping('1547', 12100, ['4081']),
+  mapping('1548', 12101, ['4082']),
+  mapping('1549', 12103, ['4106']),
+  mapping('1550', 12105, ['4084']),
+  mapping('1551', 12106, ['4085']),
+  mapping('1552', 12108, ['4086']),
+  mapping('1553', 12109, ['4087']),
+  mapping('1554', 12113, ['4088']),
+  mapping('1555', 12114, ['4089']),
+  mapping('1556', 12121, ['4091']),
+  mapping('1557', 12117, ['4092']),
+  mapping('1558', 12118, ['4113']),
+  mapping('1559', 12119, ['4094']),
+  mapping('1561', 12120, ['4095']),
+  mapping('1562', 12127, ['4093']),
+  mapping('1563', 12122, ['4097']),
+  mapping('1564', 12128, ['4096']),
+  mapping('1565', 12123, ['4099']),
+  mapping('1567', 12125, ['4100']),
+  mapping('1568', 12126, ['4070']),
+  mapping('1570', 12129, ['4101']),
+  mapping('1572', 12130, ['4102']),
+  mapping('1575', 12133, ['4103']),
+  mapping('1576', 12134, ['4104']),
+  mapping('1577', 12138, ['4105']),
+  mapping('1578', 12141, ['4068']),
+  mapping('1579', 12142, ['4076']),
+  mapping('1580', 12143, ['4067']),
+  mapping('3934', 16712, ['4078']),
+  mapping('3935', 16713, ['4114']),
+];
+
+export const SANDRE_APPROVED_SYNC_SNAPSHOTS: readonly SandreApprovedSyncSnapshot[] =
+  Object.freeze([
+    approval({
+      approvalId: 'dep24-snapshot-b8ea0408',
+      departmentCode: '24',
+      snapshotHash:
+        'b8ea0408f5ae1910f1ff51d68e6ad81a6f46f08cb4df5d84c0fff3ad624f86b0',
+      sourceUpdatedAt: '2026-08-05',
+      featureCount: 110,
+      featureEvidenceFingerprint:
+        '0b11da69b6e8f526a3c543078d8c926d9a18f8f85ce5cc9ab78eb0f86fd0aac1',
+      expectedSourceCount: 54,
+      expectedTargetCount: 55,
+      mappings: DEPARTMENT_24_MAPPINGS,
+      mdmRecords: [],
+      mdmNomenclature: null,
+    }),
+    approval({
+      approvalId: 'dep85-split-355-snapshot-934aa655',
+      departmentCode: '85',
+      snapshotHash:
+        '934aa655f60af4ee61f5ba533b365b4ba75dc37671f95ab2b73c99a03b008324',
+      sourceUpdatedAt: '2026-06-30',
+      featureCount: 26,
+      featureEvidenceFingerprint:
+        'df2652912748bb7847e7d67c49b2647c6624ad13818874089d3a49c20961248f',
+      expectedSourceCount: 1,
+      expectedTargetCount: 2,
+      mappings: [
+        partitionMapping('355', 10582, ['3947', '3948'], '2026-06-30', {
+          sourceGeometryHash: '22fe8aef4b0c2742a1adc3caa9e31ccc',
+          targetGeometryHashes: [
+            'e5f1c73a7d9322e889f65d838a176a47',
+            '73d4b862c4f9972f6d8b2d6f85f0085b',
+          ],
+          unionGeometryHash: '6e8a2ec00f197fcdb664122695102ffc',
+          sourceCoverage: 0.9999888461090162,
+          targetCoverage: 0.9999894571755797,
+          iou: 0.9999783035197829,
+        }),
+      ],
+      mdmRecords: [
+        {
+          codeSandre: '355',
+          projectionSha256:
+            'b7b16963402b459df4f882bc18962a284167d725fd05e718ca1ac68666b97504',
+          requiredEvolution: null,
+        },
+        {
+          codeSandre: '3947',
+          projectionSha256:
+            '098dd3dc60cfdda243c57446c3ae65239236f7fc7e4b6bc3bc783e262497d2fa',
+          requiredEvolution: {
+            typeNid: '282836',
+            date: '2026-06-30 00:00:00',
+            comment: 'Division de la ZAS 355',
+          },
+        },
+        {
+          codeSandre: '3948',
+          projectionSha256:
+            '7ae78c09c40975d09e3ce51bc8b7db433fd0651b178d501e38a0e112f8f59b06',
+          requiredEvolution: {
+            typeNid: '282836',
+            date: '2026-06-30 00:00:00',
+            comment: 'Division de la ZAS 355',
+          },
+        },
+      ],
+      mdmNomenclature: {
+        nid: '282836',
+        nomenclatureCode: '590',
+        title: 'Création',
+        code: '7',
+        mnemonic: 'Création',
+        projectionSha256:
+          'a14aea447a72ba382e3645c02b89dda903c38f2b147cab46b605ff455387020d',
+      },
+    }),
+  ]);
+
+export function findSandreApprovedSyncSnapshot(
+  departmentCode: string,
+  snapshot: SandreZoneSnapshot,
+): SandreApprovedSyncSnapshot | null {
+  const approval =
+    SANDRE_APPROVED_SYNC_SNAPSHOTS.find(
+      (candidate) => candidate.departmentCode === departmentCode,
+    ) ?? null;
+  if (
+    !approval ||
+    snapshot.snapshotHash !== approval.snapshotHash ||
+    snapshot.sourceUpdatedAt !== approval.sourceUpdatedAt ||
+    snapshot.featureCount !== approval.featureCount
+  ) {
+    return null;
+  }
+
+  const featureEvidence = sandreSnapshotFeatureEvidence(snapshot);
+  if (fingerprint(featureEvidence) !== approval.featureEvidenceFingerprint) {
+    throw new Error(
+      `Approved Sandre feature evidence changed for department ${departmentCode}`,
+    );
+  }
+  const featuresByCode = new Map(
+    snapshot.features.map((feature) => [feature.codeSandre, feature]),
+  );
+  for (const item of approval.mappings) {
+    assertFeature(featuresByCode.get(item.sourceCode), item.sourceCode, 'Gelé');
+    for (const targetCode of item.targetCodes) {
+      assertFeature(featuresByCode.get(targetCode), targetCode, 'Validé');
+    }
+  }
+  return approval;
+}
+
+export function sandreSnapshotFeatureEvidence(
+  snapshot: SandreZoneSnapshot,
+): Array<{
+  codeSandre: string;
+  gid: number;
+  status: string;
+  type: string;
+  payloadHash: string;
+  geometryHash: string;
+}> {
+  return snapshot.features
+    .map((feature) => ({
+      codeSandre: feature.codeSandre,
+      gid: feature.gid,
+      status: feature.status,
+      type: feature.type,
+      payloadHash: feature.payloadHash,
+      geometryHash: fingerprint({
+        type: feature.geometry?.type,
+        coordinates: feature.geometry?.coordinates,
+      }),
+    }))
+    .sort((left, right) => left.codeSandre.localeCompare(right.codeSandre));
+}
+
+export async function auditSandreApprovedSyncGeometry(
+  executor: SandreApprovedGeometryQueryExecutor,
+  mapping: SandreApprovedSyncMapping,
+  targetFeatures: SandreZoneFeature[],
+): Promise<SandreApprovedGeometryEvidence> {
+  if (
+    targetFeatures.length !== mapping.targetCodes.length ||
+    targetFeatures.some(
+      (feature) => !mapping.targetCodes.includes(feature.codeSandre),
+    )
+  ) {
+    throw new Error(
+      `Approved Sandre targets changed for source ${mapping.sourceCode}`,
+    );
+  }
+  const [row] = await executor.query(
+    `
+      WITH source AS (
+        SELECT geom
+        FROM zone_alerte
+        WHERE id = $1
+      ), target_items AS (
+        SELECT
+          item.code,
+          ST_Multi(ST_CollectionExtract(ST_MakeValid(
+            ST_SetSRID(ST_GeomFromGeoJSON(item.geometry::text), 4326)
+          ), 3)) AS geom
+        FROM jsonb_to_recordset($2::jsonb)
+          AS item(code text, geometry jsonb)
+      ), targets AS (
+        SELECT
+          ST_UnaryUnion(ST_Collect(geom)) AS geom,
+          array_agg(md5(ST_AsEWKB(geom)) ORDER BY code) AS hashes,
+          bool_and(ST_IsValid(geom)) AS valid,
+          min(ST_SRID(geom)) AS min_srid,
+          max(ST_SRID(geom)) AS max_srid
+        FROM target_items
+      ), overlap AS (
+        SELECT COALESCE(sum(ST_Area(ST_Intersection(left_item.geom, right_item.geom))), 0)
+          AS area
+        FROM target_items left_item
+        JOIN target_items right_item ON left_item.code < right_item.code
+      ), measured AS (
+        SELECT
+          source.geom AS source_geom,
+          targets.geom AS target_geom,
+          targets.hashes,
+          targets.valid AS targets_valid,
+          targets.min_srid,
+          targets.max_srid,
+          overlap.area AS overlap_area,
+          ST_Area(source.geom) AS source_area,
+          ST_Area(targets.geom) AS target_area,
+          ST_Area(ST_Intersection(source.geom, targets.geom)) AS intersection_area,
+          ST_Area(ST_Union(source.geom, targets.geom)) AS union_area
+        FROM source, targets, overlap
+      )
+      SELECT
+        md5(ST_AsEWKB(source_geom)) AS "sourceGeometryHash",
+        hashes AS "targetGeometryHashes",
+        md5(ST_AsEWKB(target_geom)) AS "unionGeometryHash",
+        CASE WHEN source_area = 0 THEN 0
+          ELSE intersection_area / source_area END::text AS "sourceCoverage",
+        CASE WHEN target_area = 0 THEN 0
+          ELSE intersection_area / target_area END::text AS "targetCoverage",
+        CASE WHEN union_area = 0 THEN 0
+          ELSE intersection_area / union_area END::text AS iou,
+        CASE WHEN target_area = 0 THEN 0
+          ELSE overlap_area / target_area END::text AS "pairwiseOverlapRatio",
+        ST_Equals(source_geom, target_geom) AS "topologicallyEqual",
+        ST_IsValid(source_geom) AS "sourceValid",
+        targets_valid AS "targetsValid",
+        ST_SRID(source_geom) AS "sourceSrid",
+        CASE WHEN min_srid = max_srid THEN min_srid ELSE NULL END AS "targetsSrid",
+        GeometryType(source_geom) AS "sourceType",
+        GeometryType(target_geom) AS "targetType"
+      FROM measured
+    `,
+    [
+      mapping.sourceZoneId,
+      JSON.stringify(
+        targetFeatures.map((feature) => ({
+          code: feature.codeSandre,
+          geometry: feature.geometry,
+        })),
+      ),
+    ],
+  );
+  if (!row) {
+    throw new Error(
+      `Approved Sandre source zone ${mapping.sourceZoneId} is missing`,
+    );
+  }
+  const evidence: SandreApprovedGeometryEvidence = {
+    sourceGeometryHash: String(row.sourceGeometryHash),
+    targetGeometryHashes: row.targetGeometryHashes ?? [],
+    unionGeometryHash: String(row.unionGeometryHash),
+    sourceCoverage: Number(row.sourceCoverage),
+    targetCoverage: Number(row.targetCoverage),
+    iou: Number(row.iou),
+    pairwiseOverlapRatio: Number(row.pairwiseOverlapRatio),
+    topologicallyEqual: row.topologicallyEqual === true,
+    sourceValid: row.sourceValid === true,
+    targetsValid: row.targetsValid === true,
+    sourceSrid: Number(row.sourceSrid),
+    targetsSrid: Number(row.targetsSrid),
+    sourceType: String(row.sourceType),
+    targetType: String(row.targetType),
+  };
+  if (
+    !evidence.sourceValid ||
+    !evidence.targetsValid ||
+    evidence.sourceSrid !== 4326 ||
+    evidence.targetsSrid !== 4326 ||
+    !['POLYGON', 'MULTIPOLYGON'].includes(evidence.sourceType) ||
+    !['POLYGON', 'MULTIPOLYGON'].includes(evidence.targetType) ||
+    evidence.sourceCoverage < mapping.minimumGeometry.sourceCoverage ||
+    evidence.targetCoverage < mapping.minimumGeometry.targetCoverage ||
+    evidence.iou < mapping.minimumGeometry.iou ||
+    evidence.pairwiseOverlapRatio > 1e-10 ||
+    (mapping.requireTopologicalEquality && !evidence.topologicallyEqual) ||
+    (mapping.expectedGeometry !== null &&
+      (evidence.sourceGeometryHash !==
+        mapping.expectedGeometry.sourceGeometryHash ||
+        evidence.unionGeometryHash !==
+          mapping.expectedGeometry.unionGeometryHash ||
+        fingerprint(evidence.targetGeometryHashes) !==
+          fingerprint(mapping.expectedGeometry.targetGeometryHashes)))
+  ) {
+    throw new Error(
+      `Approved Sandre geometry changed for source ${mapping.sourceCode}`,
+    );
+  }
+  return evidence;
+}
+
+export async function assertSandreApprovedMaterializedTargets(
+  executor: SandreApprovedGeometryQueryExecutor,
+  departmentId: number,
+  targets: Array<{
+    feature: SandreZoneFeature;
+    zoneAlerteId: number;
+  }>,
+): Promise<void> {
+  const rows = await executor.query(
+    `
+      WITH expected AS (
+        SELECT
+          item.code,
+          item."zoneAlerteId",
+          ST_Multi(ST_CollectionExtract(ST_MakeValid(
+            ST_SetSRID(ST_GeomFromGeoJSON(item.geometry::text), 4326)
+          ), 3)) AS geom
+        FROM jsonb_to_recordset($2::jsonb) AS item(
+          code text,
+          "zoneAlerteId" integer,
+          geometry jsonb
+        )
+      )
+      SELECT
+        expected.code,
+        zone.id AS "zoneAlerteId",
+        zone."codeSandre",
+        zone.disabled,
+        zone.type,
+        zone."departementId",
+        md5(ST_AsEWKB(zone.geom)) AS "localGeometryHash",
+        md5(ST_AsEWKB(expected.geom)) AS "expectedGeometryHash",
+        ST_Equals(zone.geom, expected.geom) AS "topologicallyEqual"
+      FROM expected
+      LEFT JOIN zone_alerte zone
+        ON zone.id = expected."zoneAlerteId"
+        AND zone."departementId" = $1
+      ORDER BY expected.code
+    `,
+    [
+      departmentId,
+      JSON.stringify(
+        targets.map(({ feature, zoneAlerteId }) => ({
+          code: feature.codeSandre,
+          zoneAlerteId,
+          geometry: feature.geometry,
+        })),
+      ),
+    ],
+  );
+  if (
+    rows.length !== targets.length ||
+    rows.some(
+      (row) =>
+        !Number.isInteger(Number(row.zoneAlerteId)) ||
+        row.codeSandre !== row.code ||
+        row.disabled !== false ||
+        row.type !== 'SUP' ||
+        Number(row.departementId) !== departmentId ||
+        row.localGeometryHash !== row.expectedGeometryHash ||
+        row.topologicallyEqual !== true,
+    )
+  ) {
+    throw new Error('Approved Sandre materialized target geometry changed');
+  }
+}
+
+function mapping(
+  sourceCode: string,
+  sourceZoneId: number,
+  targetCodes: string[],
+): SandreApprovedSyncMapping {
+  return {
+    sourceCode,
+    sourceZoneId,
+    targetCodes,
+    requireTopologicalEquality: targetCodes.length === 1,
+    effectiveDate: null,
+    expectedGeometry: null,
+    minimumGeometry: {
+      sourceCoverage: 0.999999999,
+      targetCoverage: 0.999999999,
+      iou: 0.999999999,
+    },
+  };
+}
+
+function partitionMapping(
+  sourceCode: string,
+  sourceZoneId: number,
+  targetCodes: string[],
+  effectiveDate: string,
+  expectedGeometry: NonNullable<SandreApprovedSyncMapping['expectedGeometry']>,
+): SandreApprovedSyncMapping {
+  const margin = 1e-7;
+  return {
+    sourceCode,
+    sourceZoneId,
+    targetCodes,
+    requireTopologicalEquality: false,
+    effectiveDate,
+    expectedGeometry,
+    minimumGeometry: {
+      sourceCoverage: expectedGeometry.sourceCoverage - margin,
+      targetCoverage: expectedGeometry.targetCoverage - margin,
+      iou: expectedGeometry.iou - margin,
+    },
+  };
+}
+
+function approval(
+  value: SandreApprovedSyncSnapshot,
+): SandreApprovedSyncSnapshot {
+  const sources = value.mappings.map((item) => item.sourceCode);
+  const sourceIds = value.mappings.map((item) => item.sourceZoneId);
+  const targets = value.mappings.flatMap((item) => item.targetCodes);
+  const approvedCodes = new Set([...sources, ...targets]);
+  const mdmCodes = value.mdmRecords.map((record) => record.codeSandre);
+  const splitMappings = value.mappings.filter(
+    (item) => item.targetCodes.length > 1,
+  );
+  const mdmEvidenceInvalid =
+    value.mdmRecords.length === 0
+      ? value.mdmNomenclature !== null
+      : !value.mdmNomenclature ||
+        new Set(mdmCodes).size !== approvedCodes.size ||
+        [...approvedCodes].some((code) => !mdmCodes.includes(code)) ||
+        fingerprint({
+          nid: value.mdmNomenclature.nid,
+          nomenclatureCode: value.mdmNomenclature.nomenclatureCode,
+          title: value.mdmNomenclature.title,
+          code: value.mdmNomenclature.code,
+          mnemonic: value.mdmNomenclature.mnemonic,
+        }) !== value.mdmNomenclature.projectionSha256 ||
+        splitMappings.some((item) => {
+          const source = value.mdmRecords.find(
+            (record) => record.codeSandre === item.sourceCode,
+          );
+          return (
+            !source ||
+            source.requiredEvolution !== null ||
+            item.targetCodes.some((targetCode) => {
+              const target = value.mdmRecords.find(
+                (record) => record.codeSandre === targetCode,
+              );
+              return (
+                !target?.requiredEvolution ||
+                target.requiredEvolution.typeNid !==
+                  value.mdmNomenclature!.nid ||
+                target.requiredEvolution.date.slice(0, 10) !==
+                  item.effectiveDate
+              );
+            })
+          );
+        });
+  if (
+    !/^[a-z0-9-]{8,100}$/.test(value.approvalId) ||
+    sources.length !== value.expectedSourceCount ||
+    targets.length !== value.expectedTargetCount ||
+    new Set(sources).size !== sources.length ||
+    new Set(sourceIds).size !== sourceIds.length ||
+    new Set(targets).size !== targets.length ||
+    sources.some((source) => targets.includes(source)) ||
+    value.mappings.some(
+      (item) =>
+        !Number.isInteger(item.sourceZoneId) ||
+        item.sourceZoneId <= 0 ||
+        !/^\d{1,32}$/.test(item.sourceCode) ||
+        item.targetCodes.length === 0 ||
+        item.targetCodes.some((code) => !/^\d{1,32}$/.test(code)) ||
+        Object.values(item.minimumGeometry).some(
+          (threshold) =>
+            !Number.isFinite(threshold) || threshold < 0.9999 || threshold > 1,
+        ) ||
+        item.requireTopologicalEquality !== (item.targetCodes.length === 1) ||
+        (item.targetCodes.length === 1
+          ? item.effectiveDate !== null || item.expectedGeometry !== null
+          : !/^\d{4}-\d{2}-\d{2}$/.test(item.effectiveDate ?? '') ||
+            item.expectedGeometry === null ||
+            !/^[a-f0-9]{32}$/.test(item.expectedGeometry.sourceGeometryHash) ||
+            !/^[a-f0-9]{32}$/.test(item.expectedGeometry.unionGeometryHash) ||
+            item.expectedGeometry.targetGeometryHashes.length !==
+              item.targetCodes.length ||
+            item.expectedGeometry.targetGeometryHashes.some(
+              (hash) => !/^[a-f0-9]{32}$/.test(hash),
+            ) ||
+            Object.values({
+              sourceCoverage: item.expectedGeometry.sourceCoverage,
+              targetCoverage: item.expectedGeometry.targetCoverage,
+              iou: item.expectedGeometry.iou,
+            }).some(
+              (observed) =>
+                !Number.isFinite(observed) || observed < 0.9999 || observed > 1,
+            ) ||
+            (['sourceCoverage', 'targetCoverage', 'iou'] as const).some(
+              (key) =>
+                item.minimumGeometry[key] > item.expectedGeometry![key] ||
+                item.expectedGeometry![key] - item.minimumGeometry[key] > 1e-7,
+            )),
+    ) ||
+    new Set(mdmCodes).size !== mdmCodes.length ||
+    mdmEvidenceInvalid ||
+    value.mdmRecords.some(
+      (record) =>
+        !approvedCodes.has(record.codeSandre) ||
+        !/^[a-f0-9]{64}$/.test(record.projectionSha256) ||
+        (record.requiredEvolution !== null &&
+          (!/^\d+$/.test(record.requiredEvolution.typeNid) ||
+            !/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(
+              record.requiredEvolution.date,
+            ) ||
+            record.requiredEvolution.comment.length === 0 ||
+            record.requiredEvolution.comment.length > 500)),
+    ) ||
+    (value.mdmNomenclature !== null &&
+      (!/^\d+$/.test(value.mdmNomenclature.nid) ||
+        !/^\d+$/.test(value.mdmNomenclature.nomenclatureCode) ||
+        !/^\d+$/.test(value.mdmNomenclature.code) ||
+        value.mdmNomenclature.title.length === 0 ||
+        value.mdmNomenclature.mnemonic.length === 0 ||
+        !/^[a-f0-9]{64}$/.test(value.mdmNomenclature.projectionSha256))) ||
+    !/^[a-f0-9]{64}$/.test(value.snapshotHash) ||
+    !/^[a-f0-9]{64}$/.test(value.featureEvidenceFingerprint)
+  ) {
+    throw new Error(
+      `Invalid Sandre sync approval for department ${value.departmentCode}`,
+    );
+  }
+  return Object.freeze({
+    ...value,
+    mappings: Object.freeze(
+      value.mappings.map((item) =>
+        Object.freeze({
+          ...item,
+          targetCodes: Object.freeze([...item.targetCodes]) as string[],
+          minimumGeometry: Object.freeze({ ...item.minimumGeometry }),
+          expectedGeometry: item.expectedGeometry
+            ? Object.freeze({
+                ...item.expectedGeometry,
+                targetGeometryHashes: Object.freeze([
+                  ...item.expectedGeometry.targetGeometryHashes,
+                ]) as string[],
+              })
+            : null,
+        }),
+      ),
+    ) as SandreApprovedSyncMapping[],
+    mdmRecords: Object.freeze(
+      value.mdmRecords.map((record) =>
+        Object.freeze({
+          ...record,
+          requiredEvolution: record.requiredEvolution
+            ? Object.freeze({ ...record.requiredEvolution })
+            : null,
+        }),
+      ),
+    ) as SandreMdmZoneExpectation[],
+    mdmNomenclature: value.mdmNomenclature
+      ? Object.freeze({ ...value.mdmNomenclature })
+      : null,
+  });
+}
+
+function assertFeature(
+  feature: SandreZoneFeature | undefined,
+  expectedCode: string,
+  expectedStatus: SandreZoneFeature['status'],
+): void {
+  if (
+    !feature ||
+    feature.codeSandre !== expectedCode ||
+    feature.status !== expectedStatus ||
+    feature.type !== 'SUP'
+  ) {
+    throw new Error(
+      `Approved Sandre feature ${expectedCode}/${expectedStatus} is missing`,
+    );
+  }
+}

--- a/apps/backend-admin/src/zone_alerte/sandre-zone-sync-approved-references.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-zone-sync-approved-references.ts
@@ -1,0 +1,978 @@
+import { fingerprint } from './sandre-zone-reconciliation';
+
+export interface SandreSyncApprovalQueryExecutor {
+  query(query: string, parameters?: any[]): Promise<any[]>;
+}
+
+export interface SandreApprovedRestrictionEvidence {
+  restrictionId: number;
+  arreteRestrictionId: number;
+  parentStatus: string;
+  parentDateDebut: string | null;
+  payloadFingerprint: string;
+  computedIds: number[];
+  historicIds: number[];
+}
+
+export interface SandreApprovedReferenceEvidence {
+  sourceZoneId: number;
+  lifecycle: 'pre_apply' | 'post_apply' | 'empty';
+  sourceOperationalEmpty: boolean;
+  arreteCadreLinks: Array<{ arreteCadreId: number; parentStatus: string }>;
+  restrictions: SandreApprovedRestrictionEvidence[];
+  customizationCount: number;
+  aliasCount: number;
+  targetCollisionFingerprint: string;
+  targetStateFingerprint: string;
+  targetState: SandreApprovedTargetOperationalState[];
+  fingerprint: string;
+}
+
+interface RestrictionPayloadRow extends SandreApprovedRestrictionEvidence {
+  zoneAlerteId: number;
+  payload: Record<string, unknown>;
+  communeIds: number[];
+  usagePayloads: Record<string, unknown>[];
+}
+
+export async function lockSandreApprovedSyncReferences(
+  executor: SandreSyncApprovalQueryExecutor,
+  sourceZoneIds: number[],
+  targetZoneIds: number[],
+): Promise<void> {
+  const zoneIds = [...new Set([...sourceZoneIds, ...targetZoneIds])].sort(
+    (left, right) => left - right,
+  );
+  await executor.query(
+    `
+      SELECT id
+      FROM zone_alerte
+      WHERE id = ANY($1::integer[])
+      ORDER BY id
+      FOR UPDATE
+    `,
+    [zoneIds],
+  );
+  await executor.query(
+    `
+      SELECT parent.id
+      FROM arrete_cadre parent
+      WHERE parent.id IN (
+        SELECT link."arreteCadreId"
+        FROM arrete_cadre_zone_alerte link
+        WHERE link."zoneAlerteId" = ANY($1::integer[])
+        UNION
+        SELECT link."arreteCadreId"
+        FROM arrete_cadre_zone_alerte_communes link
+        WHERE link."zoneAlerteId" = ANY($1::integer[])
+      )
+      ORDER BY parent.id
+      FOR SHARE OF parent
+    `,
+    [zoneIds],
+  );
+  await executor.query(
+    `
+      SELECT parent.id
+      FROM arrete_restriction parent
+      WHERE parent.id IN (
+        SELECT restriction."arreteRestrictionId"
+        FROM restriction
+        WHERE restriction."zoneAlerteId" = ANY($1::integer[])
+      )
+      ORDER BY parent.id
+      FOR SHARE OF parent
+    `,
+    [zoneIds],
+  );
+  for (const { table, orderBy, where } of [
+    {
+      table: 'arrete_cadre_zone_alerte',
+      orderBy: '"arreteCadreId", "zoneAlerteId"',
+      where: '"zoneAlerteId" = ANY($1::integer[])',
+    },
+    {
+      table: 'restriction',
+      orderBy: 'id',
+      where: '"zoneAlerteId" = ANY($1::integer[])',
+    },
+    {
+      table: 'arrete_cadre_zone_alerte_communes',
+      orderBy: 'id',
+      where: '"zoneAlerteId" = ANY($1::integer[])',
+    },
+    {
+      table: 'sandre_zone_alias',
+      orderBy: 'id',
+      where: '"zoneAlerteId" = ANY($1::integer[])',
+    },
+  ]) {
+    await executor.query(
+      `SELECT * FROM ${table} WHERE ${where} ORDER BY ${orderBy} FOR UPDATE`,
+      [zoneIds],
+    );
+  }
+  await executor.query(
+    `
+      SELECT usage.*
+      FROM usage
+      JOIN restriction ON restriction.id = usage."restrictionId"
+      WHERE restriction."zoneAlerteId" = ANY($1::integer[])
+      ORDER BY usage.id
+      FOR UPDATE OF usage
+    `,
+    [zoneIds],
+  );
+  await executor.query(
+    `
+      SELECT link.*
+      FROM restriction_commune link
+      JOIN restriction ON restriction.id = link."restrictionId"
+      WHERE restriction."zoneAlerteId" = ANY($1::integer[])
+      ORDER BY link."restrictionId", link."communeId"
+      FOR UPDATE OF link
+    `,
+    [zoneIds],
+  );
+  for (const table of [
+    'zone_alerte_computed',
+    'zone_alerte_computed_historic',
+  ]) {
+    await executor.query(
+      `
+        SELECT computed.*
+        FROM ${table} computed
+        JOIN restriction ON restriction.id = computed."restrictionId"
+        WHERE restriction."zoneAlerteId" = ANY($1::integer[])
+        ORDER BY computed.id
+        FOR SHARE OF computed
+      `,
+      [zoneIds],
+    );
+  }
+}
+
+export async function loadSandreApprovedReferenceEvidence(
+  executor: SandreSyncApprovalQueryExecutor,
+  sourceZoneId: number,
+  targetZoneIds: number[],
+  lineage?: SandreApprovedReferenceEvidence,
+): Promise<SandreApprovedReferenceEvidence> {
+  if (lineage && lineage.sourceZoneId !== sourceZoneId) {
+    throw new Error('Approved Sandre reference lineage source changed');
+  }
+  const currentArreteCadreLinks = (
+    await executor.query(
+      `
+        SELECT
+          link."arreteCadreId",
+          parent.statut AS "parentStatus"
+        FROM arrete_cadre_zone_alerte link
+        JOIN arrete_cadre parent ON parent.id = link."arreteCadreId"
+        WHERE link."zoneAlerteId" = $1
+          AND parent.statut IN ('a_venir', 'publie')
+        ORDER BY link."arreteCadreId"
+      `,
+      [sourceZoneId],
+    )
+  ).map((row) => ({
+    arreteCadreId: Number(row.arreteCadreId),
+    parentStatus: String(row.parentStatus),
+  }));
+  const currentRestrictions = await loadRestrictionPayloadRows(executor, [
+    sourceZoneId,
+  ]);
+  const [{ customizationCount = 0, aliasCount = 0 } = {}] =
+    await executor.query(
+      `
+        SELECT
+          (SELECT count(*)::integer
+           FROM arrete_cadre_zone_alerte_communes customization
+           JOIN arrete_cadre parent
+             ON parent.id = customization."arreteCadreId"
+           WHERE customization."zoneAlerteId" = $1
+             AND parent.statut IN ('a_venir', 'publie'))
+            AS "customizationCount",
+          (SELECT count(*)::integer
+           FROM sandre_zone_alias
+           WHERE "zoneAlerteId" = $1) AS "aliasCount"
+      `,
+      [sourceZoneId],
+    );
+  const parentIds = currentRestrictions.map((row) => row.arreteRestrictionId);
+  const targetCollisions = (
+    await loadRestrictionPayloadRows(executor, targetZoneIds)
+  )
+    .filter((row) => parentIds.includes(row.arreteRestrictionId))
+    .map((row) => ({
+      zoneAlerteId: row.zoneAlerteId,
+      arreteRestrictionId: row.arreteRestrictionId,
+      payloadFingerprint: row.payloadFingerprint,
+    }))
+    .sort(compareTargetRestriction);
+  const targetState = await loadTargetOperationalState(executor, targetZoneIds);
+  const sourceHasReferences =
+    currentArreteCadreLinks.length > 0 ||
+    currentRestrictions.length > 0 ||
+    Number(customizationCount) > 0 ||
+    Number(aliasCount) > 0;
+  const targetHasReferences = targetState.some(
+    (target) =>
+      target.arreteCadreIds.length > 0 ||
+      target.restrictions.length > 0 ||
+      target.customizationCount > 0 ||
+      target.aliasCount > 0,
+  );
+  if (lineage?.lifecycle === 'post_apply' && sourceHasReferences) {
+    throw new Error('Approved Sandre source regained operational references');
+  }
+  if (!sourceHasReferences && targetHasReferences && !lineage) {
+    throw new Error('Approved Sandre post-apply state has no lineage');
+  }
+  const lifecycle: SandreApprovedReferenceEvidence['lifecycle'] =
+    sourceHasReferences ? 'pre_apply' : lineage ? 'post_apply' : 'empty';
+  const arreteCadreLinks = sourceHasReferences
+    ? currentArreteCadreLinks
+    : (lineage?.arreteCadreLinks ?? []);
+  const restrictions = sourceHasReferences
+    ? currentRestrictions.map(restrictionEvidence)
+    : (lineage?.restrictions ?? []);
+  if (lifecycle === 'post_apply') {
+    await assertPostApplyLineage(executor, lineage!, targetZoneIds);
+  }
+  const evidenceWithoutFingerprint = {
+    sourceZoneId,
+    lifecycle,
+    sourceOperationalEmpty: !sourceHasReferences,
+    arreteCadreLinks,
+    restrictions,
+    customizationCount: Number(customizationCount),
+    aliasCount: Number(aliasCount),
+    targetCollisionFingerprint: fingerprint(targetCollisions),
+    targetStateFingerprint: fingerprint(targetState),
+    targetState,
+  };
+  return {
+    ...evidenceWithoutFingerprint,
+    fingerprint: fingerprint(evidenceWithoutFingerprint),
+  };
+}
+
+export function parseSandreApprovedReferenceEvidence(
+  value: unknown,
+): SandreApprovedReferenceEvidence {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid audited Sandre reference evidence');
+  }
+  const evidence = value as SandreApprovedReferenceEvidence;
+  if (
+    !Number.isInteger(evidence.sourceZoneId) ||
+    evidence.sourceZoneId <= 0 ||
+    !['pre_apply', 'post_apply', 'empty'].includes(evidence.lifecycle) ||
+    typeof evidence.sourceOperationalEmpty !== 'boolean' ||
+    evidence.sourceOperationalEmpty !== (evidence.lifecycle !== 'pre_apply') ||
+    !Array.isArray(evidence.arreteCadreLinks) ||
+    !Array.isArray(evidence.restrictions) ||
+    !Number.isInteger(evidence.customizationCount) ||
+    !Number.isInteger(evidence.aliasCount) ||
+    !/^[a-f0-9]{64}$/.test(evidence.targetCollisionFingerprint) ||
+    !/^[a-f0-9]{64}$/.test(evidence.targetStateFingerprint) ||
+    !Array.isArray(evidence.targetState) ||
+    !/^[a-f0-9]{64}$/.test(evidence.fingerprint) ||
+    evidence.arreteCadreLinks.some(
+      (link) =>
+        !Number.isInteger(link.arreteCadreId) ||
+        typeof link.parentStatus !== 'string',
+    ) ||
+    evidence.restrictions.some(
+      (restriction) =>
+        !Number.isInteger(restriction.restrictionId) ||
+        !Number.isInteger(restriction.arreteRestrictionId) ||
+        typeof restriction.parentStatus !== 'string' ||
+        (restriction.parentDateDebut !== null &&
+          typeof restriction.parentDateDebut !== 'string') ||
+        !/^[a-f0-9]{64}$/.test(restriction.payloadFingerprint) ||
+        !Array.isArray(restriction.computedIds) ||
+        !Array.isArray(restriction.historicIds),
+    ) ||
+    evidence.targetState.some(
+      (target) =>
+        !Number.isInteger(target.targetIndex) ||
+        target.targetIndex < 0 ||
+        !Array.isArray(target.arreteCadreIds) ||
+        !Array.isArray(target.restrictions) ||
+        !Number.isInteger(target.customizationCount) ||
+        !Number.isInteger(target.aliasCount),
+    ) ||
+    fingerprint(evidence.targetState) !== evidence.targetStateFingerprint
+  ) {
+    throw new Error('Invalid audited Sandre reference evidence');
+  }
+  const unsigned = {
+    sourceZoneId: evidence.sourceZoneId,
+    lifecycle: evidence.lifecycle,
+    sourceOperationalEmpty: evidence.sourceOperationalEmpty,
+    arreteCadreLinks: evidence.arreteCadreLinks,
+    restrictions: evidence.restrictions,
+    customizationCount: evidence.customizationCount,
+    aliasCount: evidence.aliasCount,
+    targetCollisionFingerprint: evidence.targetCollisionFingerprint,
+    targetStateFingerprint: evidence.targetStateFingerprint,
+    targetState: evidence.targetState,
+  };
+  if (fingerprint(unsigned) !== evidence.fingerprint) {
+    throw new Error('Audited Sandre reference evidence fingerprint changed');
+  }
+  return evidence;
+}
+
+export async function assertSandreApprovedOneToOneApplied(
+  executor: SandreSyncApprovalQueryExecutor,
+  expected: SandreApprovedReferenceEvidence,
+  targetZoneId: number,
+): Promise<void> {
+  if (expected.customizationCount !== 0 || expected.aliasCount !== 0) {
+    throw new Error(
+      `Approved Sandre 1:1 ${expected.sourceZoneId} has unsupported customizations or aliases`,
+    );
+  }
+  const source = await loadSandreApprovedReferenceEvidence(
+    executor,
+    expected.sourceZoneId,
+    [targetZoneId],
+    expected,
+  );
+  if (!source.sourceOperationalEmpty) {
+    throw new Error('Approved Sandre 1:1 source still has references');
+  }
+  const targetLinks = (
+    await executor.query(
+      `
+        SELECT link."arreteCadreId"
+        FROM arrete_cadre_zone_alerte link
+        JOIN arrete_cadre parent ON parent.id = link."arreteCadreId"
+        WHERE link."zoneAlerteId" = $1
+          AND parent.statut IN ('a_venir', 'publie')
+        ORDER BY link."arreteCadreId"
+      `,
+      [targetZoneId],
+    )
+  ).map((row) => Number(row.arreteCadreId));
+  if (
+    fingerprint(targetLinks) !==
+    fingerprint(expected.arreteCadreLinks.map((link) => link.arreteCadreId))
+  ) {
+    throw new Error(
+      'Approved Sandre 1:1 target framework links are incomplete',
+    );
+  }
+  const targetRestrictions = await loadRestrictionPayloadRows(executor, [
+    targetZoneId,
+  ]);
+  if (targetRestrictions.length !== expected.restrictions.length) {
+    throw new Error('Approved Sandre 1:1 target restrictions changed');
+  }
+  for (const restriction of expected.restrictions) {
+    const matches = targetRestrictions.filter(
+      (row) => row.arreteRestrictionId === restriction.arreteRestrictionId,
+    );
+    if (
+      matches.length !== 1 ||
+      matches[0].restrictionId !== restriction.restrictionId ||
+      matches[0].payloadFingerprint !== restriction.payloadFingerprint ||
+      fingerprint(matches[0].computedIds) !==
+        fingerprint(restriction.computedIds) ||
+      fingerprint(matches[0].historicIds) !==
+        fingerprint(restriction.historicIds)
+    ) {
+      throw new Error('Approved Sandre 1:1 target restriction is incomplete');
+    }
+  }
+  const [targetState] = await loadTargetOperationalState(executor, [
+    targetZoneId,
+  ]);
+  if (!targetState || targetState.customizationCount !== 0) {
+    throw new Error('Approved Sandre 1:1 target customizations changed');
+  }
+}
+
+export async function applySandreApprovedPartitionReferences(
+  executor: SandreSyncApprovalQueryExecutor,
+  expected: SandreApprovedReferenceEvidence,
+  targets: Array<{ codeSandre: string; zoneAlerteId: number }>,
+  historicalRecomputeFrom: string,
+): Promise<{ applied: boolean }> {
+  if (targets.length < 2) {
+    throw new Error('Approved Sandre partition requires at least two targets');
+  }
+  const sortedTargets = [...targets].sort((left, right) =>
+    left.codeSandre.localeCompare(right.codeSandre),
+  );
+  if (expected.customizationCount !== 0 || expected.aliasCount !== 0) {
+    throw new Error(
+      `Approved Sandre partition ${expected.sourceZoneId} has unsupported customizations or aliases`,
+    );
+  }
+  const current = await loadSandreApprovedReferenceEvidence(
+    executor,
+    expected.sourceZoneId,
+    sortedTargets.map((target) => target.zoneAlerteId),
+    expected,
+  );
+  if (current.lifecycle === 'post_apply') {
+    if (
+      expected.lifecycle === 'post_apply' &&
+      current.fingerprint !== expected.fingerprint
+    ) {
+      throw new Error(
+        `Approved Sandre partition post-apply state changed for zone ${expected.sourceZoneId}`,
+      );
+    }
+    return { applied: false };
+  }
+  if (current.fingerprint === expected.fingerprint) {
+    if (expected.lifecycle !== 'pre_apply') {
+      return { applied: false };
+    }
+  }
+  if (current.fingerprint !== expected.fingerprint) {
+    if (expected.lifecycle !== 'pre_apply') {
+      throw new Error(
+        `Approved Sandre partition post-apply state changed for zone ${expected.sourceZoneId}`,
+      );
+    }
+    throw new Error(
+      `Approved Sandre partition references changed for zone ${expected.sourceZoneId}`,
+    );
+  }
+
+  await markSandreApprovedHistoricalRecomputeDebt(
+    executor,
+    historicalRecomputeFrom,
+  );
+  await assertExactTargetRestrictionCollisions(
+    executor,
+    expected,
+    sortedTargets,
+  );
+  await executor.query(
+    `
+      INSERT INTO arrete_cadre_zone_alerte (
+        "arreteCadreId", "zoneAlerteId"
+      )
+      SELECT source."arreteCadreId", target.id
+      FROM arrete_cadre_zone_alerte source
+      JOIN arrete_cadre parent ON parent.id = source."arreteCadreId"
+      CROSS JOIN unnest($2::integer[]) AS target(id)
+      WHERE source."zoneAlerteId" = $1
+        AND parent.statut IN ('a_venir', 'publie')
+      ON CONFLICT DO NOTHING
+    `,
+    [expected.sourceZoneId, sortedTargets.map((target) => target.zoneAlerteId)],
+  );
+
+  const sourceRows = await loadRestrictionPayloadRows(executor, [
+    expected.sourceZoneId,
+  ]);
+  const primaryTarget = sortedTargets[0];
+  for (const source of sourceRows) {
+    for (const target of sortedTargets.slice(1)) {
+      const existing = await loadRestrictionPayloadRows(executor, [
+        target.zoneAlerteId,
+      ]);
+      const collisions = existing.filter(
+        (row) => row.arreteRestrictionId === source.arreteRestrictionId,
+      );
+      if (collisions.length === 1) {
+        if (collisions[0].payloadFingerprint !== source.payloadFingerprint) {
+          throw new Error(
+            `Approved Sandre partition restriction collision differs on target ${target.codeSandre}`,
+          );
+        }
+        continue;
+      }
+      if (collisions.length > 1) {
+        throw new Error(
+          `Approved Sandre partition has duplicate restriction collisions on target ${target.codeSandre}`,
+        );
+      }
+      await cloneRestriction(
+        executor,
+        source.restrictionId,
+        target.zoneAlerteId,
+      );
+    }
+    const primaryCollision = (
+      await loadRestrictionPayloadRows(executor, [primaryTarget.zoneAlerteId])
+    ).filter((row) => row.arreteRestrictionId === source.arreteRestrictionId);
+    if (primaryCollision.length > 0) {
+      throw new Error(
+        `Approved Sandre partition cannot preserve restriction ${source.restrictionId} on primary target`,
+      );
+    }
+    await executor.query(
+      `UPDATE restriction SET "zoneAlerteId" = $2 WHERE id = $1`,
+      [source.restrictionId, primaryTarget.zoneAlerteId],
+    );
+  }
+  await executor.query(
+    `
+      DELETE FROM arrete_cadre_zone_alerte link
+      USING arrete_cadre parent
+      WHERE link."arreteCadreId" = parent.id
+        AND link."zoneAlerteId" = $1
+        AND parent.statut IN ('a_venir', 'publie')
+    `,
+    [expected.sourceZoneId],
+  );
+
+  await assertSandreApprovedPartitionApplied(executor, expected, sortedTargets);
+  return { applied: true };
+}
+
+export async function markSandreApprovedHistoricalRecomputeDebt(
+  executor: SandreSyncApprovalQueryExecutor,
+  date: string | null,
+): Promise<void> {
+  if (!date) {
+    return;
+  }
+  const [lock] = await executor.query(
+    `SELECT pg_try_advisory_xact_lock(hashtext('vigieau'), hashtext('zone-compute-historic')) AS locked`,
+  );
+  if (lock?.locked !== true) {
+    throw new Error('Historic zone compute is running during Sandre split');
+  }
+  const [result] = await executor.query(
+    `
+      WITH changed AS (
+        UPDATE config
+        SET
+          "computeMapDate" = CASE
+            WHEN "computeMapDate" IS NULL OR "computeMapDate" > $1::date
+            THEN $1::date ELSE "computeMapDate" END,
+          "computeStatsDate" = CASE
+            WHEN "computeStatsDate" IS NULL OR "computeStatsDate" > $1::date
+            THEN $1::date ELSE "computeStatsDate" END,
+          "computeMapGeneration" = "computeMapGeneration" + CASE
+            WHEN "computeMapDate" IS NULL OR "computeMapDate" > $1::date
+            THEN 1 ELSE 0 END,
+          "computeStatsGeneration" = "computeStatsGeneration" + CASE
+            WHEN "computeStatsDate" IS NULL OR "computeStatsDate" > $1::date
+            THEN 1 ELSE 0 END,
+          "historicComputeEpoch" = "historicComputeEpoch" + 1
+        WHERE id = 1
+          AND (
+            "computeMapDate" IS NULL OR "computeMapDate" > $1::date
+            OR "computeStatsDate" IS NULL OR "computeStatsDate" > $1::date
+          )
+        RETURNING id
+      )
+      SELECT count(*)::integer AS count FROM changed
+    `,
+    [date],
+  );
+  if (!result || ![0, 1].includes(Number(result.count))) {
+    throw new Error('Invalid historic cursor state');
+  }
+}
+
+export async function assertSandreApprovedPartitionApplied(
+  executor: SandreSyncApprovalQueryExecutor,
+  expected: SandreApprovedReferenceEvidence,
+  targets: Array<{ codeSandre: string; zoneAlerteId: number }>,
+): Promise<void> {
+  const [primary, ...clones] = targets;
+  const source = await loadSandreApprovedReferenceEvidence(
+    executor,
+    expected.sourceZoneId,
+    targets.map((target) => target.zoneAlerteId),
+    expected,
+  );
+  if (!source.sourceOperationalEmpty) {
+    throw new Error('Approved Sandre partition source still has references');
+  }
+  for (const target of targets) {
+    const [state] = await loadTargetOperationalState(executor, [
+      target.zoneAlerteId,
+    ]);
+    const links = state?.arreteCadreIds ?? [];
+    if (
+      !state ||
+      state.customizationCount !== 0 ||
+      state.aliasCount !== 0 ||
+      fingerprint(links) !==
+        fingerprint(expected.arreteCadreLinks.map((link) => link.arreteCadreId))
+    ) {
+      throw new Error(
+        `Approved Sandre partition framework links are incomplete on ${target.codeSandre}`,
+      );
+    }
+  }
+  const primaryRows = await loadRestrictionPayloadRows(executor, [
+    primary.zoneAlerteId,
+  ]);
+  if (primaryRows.length !== expected.restrictions.length) {
+    throw new Error('Approved Sandre partition primary restrictions changed');
+  }
+  for (const restriction of expected.restrictions) {
+    const primaryMatches = primaryRows.filter(
+      (row) => row.arreteRestrictionId === restriction.arreteRestrictionId,
+    );
+    if (
+      primaryMatches.length !== 1 ||
+      primaryMatches[0].restrictionId !== restriction.restrictionId ||
+      primaryMatches[0].payloadFingerprint !== restriction.payloadFingerprint ||
+      fingerprint(primaryMatches[0].computedIds) !==
+        fingerprint(restriction.computedIds) ||
+      fingerprint(primaryMatches[0].historicIds) !==
+        fingerprint(restriction.historicIds)
+    ) {
+      throw new Error(
+        `Approved Sandre partition primary restriction ${restriction.restrictionId} is incomplete`,
+      );
+    }
+    for (const target of clones) {
+      const cloneRows = await loadRestrictionPayloadRows(executor, [
+        target.zoneAlerteId,
+      ]);
+      if (cloneRows.length !== expected.restrictions.length) {
+        throw new Error(
+          `Approved Sandre partition clone restrictions changed on ${target.codeSandre}`,
+        );
+      }
+      const matches = cloneRows.filter(
+        (row) => row.arreteRestrictionId === restriction.arreteRestrictionId,
+      );
+      if (
+        matches.length !== 1 ||
+        matches[0].parentStatus !== restriction.parentStatus ||
+        matches[0].payloadFingerprint !== restriction.payloadFingerprint ||
+        matches[0].computedIds.length !== 0 ||
+        matches[0].historicIds.length !== 0
+      ) {
+        throw new Error(
+          `Approved Sandre partition clone is incomplete on ${target.codeSandre}`,
+        );
+      }
+    }
+  }
+}
+
+async function assertExactTargetRestrictionCollisions(
+  executor: SandreSyncApprovalQueryExecutor,
+  expected: SandreApprovedReferenceEvidence,
+  targets: Array<{ codeSandre: string; zoneAlerteId: number }>,
+): Promise<void> {
+  const expectedByParent = new Map(
+    expected.restrictions.map((restriction) => [
+      restriction.arreteRestrictionId,
+      restriction,
+    ]),
+  );
+  const targetRows = await loadRestrictionPayloadRows(
+    executor,
+    targets.map((target) => target.zoneAlerteId),
+  );
+  for (const target of targetRows) {
+    const source = expectedByParent.get(target.arreteRestrictionId);
+    if (
+      source &&
+      (source.parentStatus !== target.parentStatus ||
+        source.payloadFingerprint !== target.payloadFingerprint ||
+        target.computedIds.length !== 0 ||
+        target.historicIds.length !== 0)
+    ) {
+      throw new Error(
+        `Approved Sandre partition target restriction differs for parent ${target.arreteRestrictionId}`,
+      );
+    }
+  }
+}
+
+async function cloneRestriction(
+  executor: SandreSyncApprovalQueryExecutor,
+  sourceRestrictionId: number,
+  targetZoneId: number,
+): Promise<void> {
+  const inserted = await executor.query(
+    `
+      INSERT INTO restriction
+      SELECT (
+        jsonb_populate_record(
+          NULL::restriction,
+          (to_jsonb(source) - ARRAY['id', 'zoneAlerteId']::text[])
+          || jsonb_build_object(
+            'id', nextval(pg_get_serial_sequence('restriction', 'id')),
+            'zoneAlerteId', $2::integer
+          )
+        )
+      ).*
+      FROM restriction source
+      WHERE source.id = $1
+      RETURNING id
+    `,
+    [sourceRestrictionId, targetZoneId],
+  );
+  if (inserted.length !== 1) {
+    throw new Error(
+      `Approved Sandre restriction ${sourceRestrictionId} vanished`,
+    );
+  }
+  const cloneId = Number(inserted[0].id);
+  await executor.query(
+    `
+      INSERT INTO restriction_commune ("restrictionId", "communeId")
+      SELECT $2, "communeId"
+      FROM restriction_commune
+      WHERE "restrictionId" = $1
+      ORDER BY "communeId"
+    `,
+    [sourceRestrictionId, cloneId],
+  );
+  await executor.query(
+    `
+      INSERT INTO usage
+      SELECT (
+        jsonb_populate_record(
+          NULL::usage,
+          (to_jsonb(source) - ARRAY['id', 'restrictionId']::text[])
+          || jsonb_build_object(
+            'id', nextval(pg_get_serial_sequence('usage', 'id')),
+            'restrictionId', $2::integer
+          )
+        )
+      ).*
+      FROM usage source
+      WHERE source."restrictionId" = $1
+      ORDER BY source.id
+    `,
+    [sourceRestrictionId, cloneId],
+  );
+}
+
+export interface SandreApprovedTargetOperationalState {
+  targetIndex: number;
+  arreteCadreIds: number[];
+  restrictions: SandreApprovedRestrictionEvidence[];
+  customizationCount: number;
+  aliasCount: number;
+}
+
+async function loadTargetOperationalState(
+  executor: SandreSyncApprovalQueryExecutor,
+  targetZoneIds: number[],
+): Promise<SandreApprovedTargetOperationalState[]> {
+  const restrictionRows = await loadRestrictionPayloadRows(
+    executor,
+    targetZoneIds,
+  );
+  const links = await executor.query(
+    `
+      SELECT
+        target.id AS "zoneAlerteId",
+        COALESCE(array_agg(link."arreteCadreId" ORDER BY link."arreteCadreId")
+          FILTER (WHERE parent.id IS NOT NULL), '{}') AS "arreteCadreIds",
+        (SELECT count(*)::integer
+         FROM arrete_cadre_zone_alerte_communes customization
+         JOIN arrete_cadre parent
+           ON parent.id = customization."arreteCadreId"
+         WHERE customization."zoneAlerteId" = target.id
+           AND parent.statut IN ('a_venir', 'publie')) AS "customizationCount",
+        (SELECT count(*)::integer
+         FROM sandre_zone_alias alias
+         WHERE alias."zoneAlerteId" = target.id) AS "aliasCount"
+      FROM unnest($1::integer[]) WITH ORDINALITY target(id, position)
+      LEFT JOIN arrete_cadre_zone_alerte link
+        ON link."zoneAlerteId" = target.id
+      LEFT JOIN arrete_cadre parent
+        ON parent.id = link."arreteCadreId"
+        AND parent.statut IN ('a_venir', 'publie')
+      GROUP BY target.id, target.position
+      ORDER BY target.position
+    `,
+    [targetZoneIds],
+  );
+  return links.map((row, targetIndex) => ({
+    targetIndex,
+    arreteCadreIds: (row.arreteCadreIds ?? []).map(Number),
+    restrictions: restrictionRows
+      .filter(
+        (restriction) => restriction.zoneAlerteId === Number(row.zoneAlerteId),
+      )
+      .map(restrictionEvidence),
+    customizationCount: Number(row.customizationCount),
+    aliasCount: Number(row.aliasCount),
+  }));
+}
+
+async function assertPostApplyLineage(
+  executor: SandreSyncApprovalQueryExecutor,
+  lineage: SandreApprovedReferenceEvidence,
+  targetZoneIds: number[],
+): Promise<void> {
+  if (targetZoneIds.length === 0) {
+    throw new Error('Approved Sandre post-apply state has no target');
+  }
+  const allRestrictions = await loadRestrictionPayloadRows(
+    executor,
+    targetZoneIds,
+    false,
+  );
+  const allLinks = await executor.query(
+    `
+      SELECT "zoneAlerteId", "arreteCadreId"
+      FROM arrete_cadre_zone_alerte
+      WHERE "zoneAlerteId" = ANY($1::integer[])
+      ORDER BY "zoneAlerteId", "arreteCadreId"
+    `,
+    [targetZoneIds],
+  );
+  for (const [targetIndex, targetZoneId] of targetZoneIds.entries()) {
+    const requiredState =
+      lineage.lifecycle === 'post_apply'
+        ? lineage.targetState.find(
+            (target) => target.targetIndex === targetIndex,
+          )
+        : null;
+    const requiredLinks = requiredState
+      ? requiredState.arreteCadreIds
+      : lineage.arreteCadreLinks.map((link) => link.arreteCadreId);
+    const actualLinks = new Set(
+      allLinks
+        .filter((link) => Number(link.zoneAlerteId) === targetZoneId)
+        .map((link) => Number(link.arreteCadreId)),
+    );
+    if (requiredLinks.some((id) => !actualLinks.has(id))) {
+      throw new Error('Approved Sandre framework lineage is incomplete');
+    }
+    const requiredRestrictions = requiredState
+      ? requiredState.restrictions
+      : lineage.restrictions;
+    for (const required of requiredRestrictions) {
+      const parentRows = allRestrictions.filter(
+        (row) =>
+          row.zoneAlerteId === targetZoneId &&
+          row.arreteRestrictionId === required.arreteRestrictionId,
+      );
+      const matches = parentRows.filter(
+        (row) =>
+          (requiredState
+            ? row.restrictionId === required.restrictionId
+            : targetIndex === 0
+              ? row.restrictionId === required.restrictionId
+              : row.arreteRestrictionId === required.arreteRestrictionId) &&
+          row.payloadFingerprint === required.payloadFingerprint,
+      );
+      if (parentRows.length !== 1 || matches.length !== 1) {
+        throw new Error('Approved Sandre restriction lineage is incomplete');
+      }
+    }
+  }
+}
+
+async function loadRestrictionPayloadRows(
+  executor: SandreSyncApprovalQueryExecutor,
+  zoneIds: number[],
+  operationalOnly = true,
+): Promise<RestrictionPayloadRow[]> {
+  if (zoneIds.length === 0) {
+    return [];
+  }
+  const rows = await executor.query(
+    `
+      SELECT
+        restriction.id AS "restrictionId",
+        restriction."zoneAlerteId",
+        restriction."arreteRestrictionId",
+        parent.statut AS "parentStatus",
+        parent."dateDebut"::text AS "parentDateDebut",
+        to_jsonb(restriction) - ARRAY['id', 'zoneAlerteId']::text[] AS payload,
+        ARRAY(
+          SELECT link."communeId"
+          FROM restriction_commune link
+          WHERE link."restrictionId" = restriction.id
+          ORDER BY link."communeId"
+        ) AS "communeIds",
+        COALESCE((
+          SELECT jsonb_agg(
+            to_jsonb(usage) - ARRAY['id', 'restrictionId']::text[]
+            ORDER BY usage.id
+          )
+          FROM usage
+          WHERE usage."restrictionId" = restriction.id
+        ), '[]'::jsonb) AS "usagePayloads",
+        ARRAY(
+          SELECT computed.id
+          FROM zone_alerte_computed computed
+          WHERE computed."restrictionId" = restriction.id
+          ORDER BY computed.id
+        ) AS "computedIds",
+        ARRAY(
+          SELECT historic.id
+          FROM zone_alerte_computed_historic historic
+          WHERE historic."restrictionId" = restriction.id
+          ORDER BY historic.id
+        ) AS "historicIds"
+      FROM restriction
+      JOIN arrete_restriction parent
+        ON parent.id = restriction."arreteRestrictionId"
+      WHERE restriction."zoneAlerteId" = ANY($1::integer[])
+        AND ($2::boolean = false OR parent.statut IN ('a_venir', 'publie'))
+      ORDER BY restriction."zoneAlerteId", restriction.id
+    `,
+    [[...zoneIds].sort((left, right) => left - right), operationalOnly],
+  );
+  return rows.map((row) => {
+    const payload = row.payload as Record<string, unknown>;
+    const communeIds = (row.communeIds ?? []).map(Number);
+    const usagePayloads = (row.usagePayloads ?? []) as Record<
+      string,
+      unknown
+    >[];
+    return {
+      restrictionId: Number(row.restrictionId),
+      zoneAlerteId: Number(row.zoneAlerteId),
+      arreteRestrictionId: Number(row.arreteRestrictionId),
+      parentStatus: String(row.parentStatus),
+      parentDateDebut: row.parentDateDebut ?? null,
+      payload,
+      communeIds,
+      usagePayloads,
+      payloadFingerprint: fingerprint({ payload, communeIds, usagePayloads }),
+      computedIds: (row.computedIds ?? []).map(Number),
+      historicIds: (row.historicIds ?? []).map(Number),
+    };
+  });
+}
+
+function restrictionEvidence(
+  row: RestrictionPayloadRow,
+): SandreApprovedRestrictionEvidence {
+  return {
+    restrictionId: row.restrictionId,
+    arreteRestrictionId: row.arreteRestrictionId,
+    parentStatus: row.parentStatus,
+    parentDateDebut: row.parentDateDebut,
+    payloadFingerprint: row.payloadFingerprint,
+    computedIds: row.computedIds,
+    historicIds: row.historicIds,
+  };
+}
+
+function compareTargetRestriction(
+  left: {
+    zoneAlerteId: number;
+    arreteRestrictionId: number;
+    payloadFingerprint: string;
+  },
+  right: {
+    zoneAlerteId: number;
+    arreteRestrictionId: number;
+    payloadFingerprint: string;
+  },
+): number {
+  return `${left.zoneAlerteId}:${left.arreteRestrictionId}:${left.payloadFingerprint}`.localeCompare(
+    `${right.zoneAlerteId}:${right.arreteRestrictionId}:${right.payloadFingerprint}`,
+  );
+}

--- a/apps/backend-admin/src/zone_alerte/zone_alerte.service.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/zone_alerte.service.spec.ts
@@ -5,6 +5,9 @@ import { SandreZoneSyncState } from '@shared/entities/sandre_zone_sync_state.ent
 import { ZoneAlerte } from '@shared/entities/zone_alerte.entity';
 import { of } from 'rxjs';
 import { getMetadataArgsStorage } from 'typeorm';
+import * as approvedReferences from './sandre-zone-sync-approved-references';
+import * as syncApprovals from './sandre-zone-sync-approvals';
+import { fingerprint } from './sandre-zone-reconciliation';
 import { createSandreZoneSnapshot } from './sandre-zone-sync';
 import { ZoneAlerteService } from './zone_alerte.service';
 
@@ -135,6 +138,7 @@ describe('ZoneAlerteService Sandre synchronization', () => {
       reason: string;
     }>;
     globalLockAvailable?: boolean;
+    exactAuditBatch?: Record<string, unknown> | null;
   }) => {
     const zoneRepository = {
       create: jest.fn(() => ({})),
@@ -181,9 +185,47 @@ describe('ZoneAlerteService Sandre synchronization', () => {
       [Departement, departmentRepository],
       [BassinVersant, basinRepository],
     ]);
+    const configuredResponses = options?.httpResponses ?? [
+      countResponse(1),
+      {
+        data: {
+          features: [rawFeature()],
+        },
+      },
+      countResponse(1),
+    ];
+    const exactAuditFeatures = configuredResponses.flatMap((response) =>
+      Array.isArray(response?.data?.features) ? response.data.features : [],
+    );
+    const getExactAuditSnapshot = () =>
+      createSandreZoneSnapshot(
+        exactAuditFeatures,
+        exactAuditFeatures.length,
+        department.code,
+      );
     const manager = {
       getRepository: jest.fn((entity) => repositories.get(entity)),
       query: jest.fn(async (query: string, parameters?: any[]) => {
+        if (
+          query.includes('FROM sandre_zone_sync_batch batch') &&
+          query.includes("batch.kind = 'snapshot'") &&
+          query.includes("batch.mode = 'audit'") &&
+          query.includes('FOR SHARE')
+        ) {
+          if (options && 'exactAuditBatch' in options) {
+            return options.exactAuditBatch ? [options.exactAuditBatch] : [];
+          }
+          const exactAuditSnapshot = getExactAuditSnapshot();
+          return [
+            {
+              id: 'exact-audit-1',
+              status: 'observed',
+              snapshotHash: exactAuditSnapshot.snapshotHash,
+              sourceUpdatedAt: exactAuditSnapshot.sourceUpdatedAt,
+              featureCount: exactAuditSnapshot.featureCount,
+            },
+          ];
+        }
         if (query.includes('WITH sandre_geometry_input AS')) {
           const inputs = JSON.parse(parameters?.[0] ?? '[]');
           return inputs.map((input, index) => {
@@ -205,6 +247,9 @@ describe('ZoneAlerteService Sandre synchronization', () => {
               raw_area: '1',
               normalized_area: '1',
               relative_area_delta: '0',
+              raw_geodesic_area: '10000000',
+              normalized_geodesic_area: '10000000',
+              absolute_geodesic_area_delta: '0',
               bbox_unchanged: true,
               normalized_valid: !invalid,
             };
@@ -321,15 +366,7 @@ describe('ZoneAlerteService Sandre synchronization', () => {
         return [];
       }),
     };
-    const responses = options?.httpResponses ?? [
-      countResponse(1),
-      {
-        data: {
-          features: [rawFeature()],
-        },
-      },
-      countResponse(1),
-    ];
+    const responses = [...configuredResponses];
     const httpService = {
       get: jest.fn(() => of(responses.shift())),
     };
@@ -394,6 +431,72 @@ describe('ZoneAlerteService Sandre synchronization', () => {
       runCurrentZoneComputeWorker,
     };
   };
+
+  it('requests the official genealogy representation explicitly', async () => {
+    const csvUrl =
+      'https://services.sandre.eaufrance.fr/telechargement/geo/ZAS/GenealogieZAS_millesime2024.csv';
+    const metadata = `
+      <root xmlns:gmd="gmd" xmlns:gco="gco">
+        <gmd:CI_OnlineResource>
+          <gmd:linkage><gmd:URL>${csvUrl}</gmd:URL></gmd:linkage>
+          <gmd:name><gco:CharacterString>Télécharger la généalogie des zones d'alerte sécheresse</gco:CharacterString></gmd:name>
+        </gmd:CI_OnlineResource>
+      </root>
+    `;
+    const csv = [
+      'id,CdZASParent,CdZASEnfant,DtGenZAS,TypGenZAS,RaisGenZAS',
+      '1,OLD,NEW,2024-10-01,2,Remplacement',
+    ].join('\n');
+    const harness = createHarness({
+      httpResponses: [{ data: metadata }, { data: csv }],
+    });
+
+    await expect(
+      (harness.service as any).fetchSandreGenealogyRelations(),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        parentCode: 'OLD',
+        childCode: 'NEW',
+        modificationType: '2',
+      }),
+    ]);
+
+    expect(harness.httpService.get).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('/formatters/xml'),
+      expect.objectContaining({
+        headers: {
+          accept: 'application/xml,text/xml,text/csv,text/html;q=0.9',
+          'accept-language': 'fr',
+        },
+        responseType: 'text',
+      }),
+    );
+    expect(harness.httpService.get).toHaveBeenNthCalledWith(
+      2,
+      csvUrl,
+      expect.objectContaining({
+        headers: {
+          accept: 'application/xml,text/xml,text/csv,text/html;q=0.9',
+          'accept-language': 'fr',
+        },
+        responseType: 'text',
+      }),
+    );
+  });
+
+  it('fails closed when Sandre serves the default JSON metadata representation', async () => {
+    const harness = createHarness({
+      httpResponses: [{ data: { distributions: [] } }],
+    });
+
+    await expect(
+      (harness.service as any).fetchSandreGenealogyRelations(),
+    ).rejects.toThrow(
+      'Expected exactly one official Sandre genealogy resource',
+    );
+    expect(harness.httpService.get).toHaveBeenCalledTimes(1);
+  });
 
   it('rejects an incomplete paginated snapshot before opening a transaction', async () => {
     const harness = createHarness({
@@ -564,6 +667,326 @@ describe('ZoneAlerteService Sandre synchronization', () => {
         [expect.stringContaining('"observedSnapshotHash"'), expect.anything()],
       ]),
     );
+  });
+
+  it('binds a virtual-target audit before promoting and splitting a strict legacy source', async () => {
+    const sourceGeometry = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+          [0, 2],
+          [0, 0],
+        ],
+      ],
+    };
+    const targetGeometryA = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 2],
+          [0, 2],
+          [0, 0],
+        ],
+      ],
+    };
+    const targetGeometryB = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [1, 0],
+          [2, 0],
+          [2, 2],
+          [1, 2],
+          [1, 0],
+        ],
+      ],
+    };
+    const raw = (
+      properties: Record<string, unknown>,
+      geometry: Record<string, unknown>,
+    ) => ({
+      ...rawFeature({
+        DateMajZAS: '2026-06-30',
+        NumCircAdminBassin: 7,
+        ...properties,
+      }),
+      geometry,
+    });
+    const snapshot = createSandreZoneSnapshot(
+      [
+        raw(
+          { gid: 464, CdZAS: '355', StZAS: 'Gelé', LbZAS: 'Source' },
+          sourceGeometry,
+        ),
+        raw(
+          { gid: 3947, CdZAS: '3947', StZAS: 'Validé', LbZAS: 'Target A' },
+          targetGeometryA,
+        ),
+        raw(
+          { gid: 3946, CdZAS: '3948', StZAS: 'Validé', LbZAS: 'Target B' },
+          targetGeometryB,
+        ),
+      ],
+      3,
+      department.code,
+    );
+    const sourceFeature = snapshot.features.find(
+      (feature) => feature.codeSandre === '355',
+    )!;
+    const targetFeatures = snapshot.features.filter((feature) =>
+      ['3947', '3948'].includes(feature.codeSandre),
+    );
+    const sourceZone = {
+      id: 10582,
+      idSandre: sourceFeature.gid,
+      codeSandre: null,
+      sandreProvenance: 'legacy_unverified',
+      disabled: false,
+      type: 'SUP',
+      statutSandre: null,
+      dateMajSandre: null,
+      numeroVersionSandre: null,
+      sandrePayloadHash: null,
+      departement: department,
+    };
+    const targetZones = targetFeatures.map((feature, index) => ({
+      id: 20001 + index,
+      idSandre: feature.gid,
+      codeSandre: feature.codeSandre,
+      sandreProvenance: 'official',
+      disabled: false,
+      type: 'SUP',
+      departement: department,
+    }));
+    const mapping = {
+      sourceCode: '355',
+      sourceZoneId: 10582,
+      targetCodes: ['3947', '3948'],
+      requireTopologicalEquality: false,
+      effectiveDate: '2026-06-30',
+      expectedGeometry: {
+        sourceGeometryHash: '1'.repeat(32),
+        targetGeometryHashes: ['2'.repeat(32), '3'.repeat(32)],
+        unionGeometryHash: '4'.repeat(32),
+        sourceCoverage: 1,
+        targetCoverage: 1,
+        iou: 1,
+      },
+      minimumGeometry: {
+        sourceCoverage: 0.9999,
+        targetCoverage: 0.9999,
+        iou: 0.9999,
+      },
+    };
+    const approval = {
+      approvalId: 'test-approved-split',
+      departmentCode: department.code,
+      snapshotHash: snapshot.snapshotHash,
+      sourceUpdatedAt: snapshot.sourceUpdatedAt!,
+      featureCount: snapshot.featureCount,
+      featureEvidenceFingerprint: '5'.repeat(64),
+      expectedSourceCount: 1,
+      expectedTargetCount: 2,
+      mappings: [mapping],
+      mdmRecords: [],
+      mdmNomenclature: null,
+    };
+    const targetState = [0, 1].map((targetIndex) => ({
+      targetIndex,
+      arreteCadreIds: [],
+      restrictions: [],
+      customizationCount: 0,
+      aliasCount: 0,
+    }));
+    const referenceEvidence = (lifecycle: 'pre_apply' | 'post_apply') => {
+      const state =
+        lifecycle === 'pre_apply'
+          ? targetState
+          : targetState.map((target) => ({
+              ...target,
+              arreteCadreIds: [700],
+            }));
+      const unsigned = {
+        sourceZoneId: sourceZone.id,
+        lifecycle,
+        sourceOperationalEmpty: lifecycle === 'post_apply',
+        arreteCadreLinks: [{ arreteCadreId: 700, parentStatus: 'publie' }],
+        restrictions: [],
+        customizationCount: 0,
+        aliasCount: 0,
+        targetCollisionFingerprint: fingerprint([]),
+        targetStateFingerprint: fingerprint(state),
+        targetState: state,
+      };
+      return { ...unsigned, fingerprint: fingerprint(unsigned) };
+    };
+    const preApplyReferences = referenceEvidence('pre_apply');
+    const postApplyLineage = referenceEvidence('post_apply');
+    const geometryEvidence = {
+      sourceGeometryHash: mapping.expectedGeometry.sourceGeometryHash,
+      targetGeometryHashes: mapping.expectedGeometry.targetGeometryHashes,
+      unionGeometryHash: mapping.expectedGeometry.unionGeometryHash,
+      sourceCoverage: 1,
+      targetCoverage: 1,
+      iou: 1,
+      pairwiseOverlapRatio: 0,
+      topologicallyEqual: true,
+      sourceValid: true,
+      targetsValid: true,
+      sourceSrid: 4326,
+      targetsSrid: 4326,
+      sourceType: 'POLYGON',
+      targetType: 'MULTIPOLYGON',
+    };
+    const mdmEvidence = {
+      approvalId: approval.approvalId,
+      zoneRecords: [],
+      nomenclature: null,
+    };
+    const harness = createHarness();
+    const geometrySpy = jest
+      .spyOn(syncApprovals, 'auditSandreApprovedSyncGeometry')
+      .mockResolvedValue(geometryEvidence);
+    const materializedSpy = jest
+      .spyOn(syncApprovals, 'assertSandreApprovedMaterializedTargets')
+      .mockResolvedValue();
+    const lockSpy = jest
+      .spyOn(approvedReferences, 'lockSandreApprovedSyncReferences')
+      .mockResolvedValue();
+    const referencesSpy = jest
+      .spyOn(approvedReferences, 'loadSandreApprovedReferenceEvidence')
+      .mockResolvedValueOnce(preApplyReferences)
+      .mockResolvedValueOnce(preApplyReferences)
+      .mockResolvedValueOnce(postApplyLineage);
+    const partitionSpy = jest
+      .spyOn(approvedReferences, 'applySandreApprovedPartitionReferences')
+      .mockResolvedValue({ applied: true });
+    const inactive = [
+      {
+        feature: sourceFeature,
+        match: { zone: sourceZone, matchType: 'legacy_gid' },
+      },
+    ];
+    const auditTargets = new Map(
+      targetFeatures.map((feature, index) => [
+        feature.codeSandre,
+        { ...targetZones[index], id: -1 - index },
+      ]),
+    );
+    const auditDecisions: any[] = [];
+
+    await (harness.service as any).reconcileApprovedSandreSnapshotMappings(
+      harness.manager,
+      department,
+      snapshot,
+      approval,
+      inactive,
+      auditTargets,
+      auditDecisions,
+      false,
+      undefined,
+      mdmEvidence,
+    );
+
+    expect(auditDecisions).toHaveLength(1);
+    expect(auditDecisions[0]).toEqual(
+      expect.objectContaining({
+        candidateZoneAlerteId: null,
+        outcome: 'observed',
+      }),
+    );
+    expect(JSON.stringify(auditDecisions[0].evidence)).not.toContain(':-1');
+    expect(lockSpy).not.toHaveBeenCalled();
+    const audited = auditDecisions[0].evidence;
+    const safeDecisions: any[] = [];
+
+    await (harness.service as any).reconcileApprovedSandreSnapshotMappings(
+      harness.manager,
+      department,
+      snapshot,
+      approval,
+      inactive,
+      new Map(
+        targetFeatures.map((feature, index) => [
+          feature.codeSandre,
+          targetZones[index],
+        ]),
+      ),
+      safeDecisions,
+      true,
+      {
+        batchId: 'audit-1',
+        decisions: new Map([['355:approved-snapshot', audited]]),
+      },
+      mdmEvidence,
+    );
+
+    expect(sourceZone).toEqual(
+      expect.objectContaining({
+        idSandre: 464,
+        codeSandre: '355',
+        sandreProvenance: 'official',
+      }),
+    );
+    expect(materializedSpy).toHaveBeenCalledWith(
+      harness.manager,
+      department.id,
+      expect.arrayContaining([
+        expect.objectContaining({ zoneAlerteId: 20001 }),
+        expect.objectContaining({ zoneAlerteId: 20002 }),
+      ]),
+    );
+    expect(partitionSpy).toHaveBeenCalledWith(
+      harness.manager,
+      preApplyReferences,
+      [
+        { codeSandre: '3947', zoneAlerteId: 20001 },
+        { codeSandre: '3948', zoneAlerteId: 20002 },
+      ],
+      '2026-06-30',
+    );
+    expect(safeDecisions[0].evidence.migrationLineage).toEqual(
+      postApplyLineage,
+    );
+    expect(referencesSpy).toHaveBeenCalledTimes(3);
+
+    materializedSpy.mockRejectedValueOnce(
+      new Error('Approved Sandre materialized target geometry changed'),
+    );
+    await expect(
+      (harness.service as any).reconcileApprovedSandreSnapshotMappings(
+        harness.manager,
+        department,
+        snapshot,
+        approval,
+        [
+          {
+            feature: sourceFeature,
+            match: { zone: sourceZone, matchType: 'canonical' },
+          },
+        ],
+        new Map(
+          targetFeatures.map((feature, index) => [
+            feature.codeSandre,
+            targetZones[index],
+          ]),
+        ),
+        [],
+        true,
+        {
+          batchId: 'audit-1',
+          decisions: new Map([['355:approved-snapshot', audited]]),
+        },
+        mdmEvidence,
+      ),
+    ).rejects.toThrow('materialized target geometry changed');
+    expect(partitionSpy).toHaveBeenCalledTimes(1);
+    expect(geometrySpy).toHaveBeenCalledTimes(2);
   });
 
   it('exposes a redacted operator status with observed, applied and blocked state', async () => {
@@ -1926,6 +2349,18 @@ describe('ZoneAlerteService Sandre synchronization', () => {
     expect(harness.queryRunner.commitTransaction).toHaveBeenCalledTimes(1);
   });
 
+  it('fails closed before the domain preflight without an exact audit', async () => {
+    const harness = createHarness({ exactAuditBatch: null });
+
+    await expect(harness.service.updateDepartementZones('65')).rejects.toThrow(
+      'successful exact-snapshot audit',
+    );
+
+    expect(harness.zoneRepository.find).not.toHaveBeenCalled();
+    expect(harness.zoneRepository.save).not.toHaveBeenCalled();
+    expect(harness.queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
+  });
+
   it('ignores a snapshot that started before the last applied snapshot', async () => {
     const snapshot = createSandreZoneSnapshot(
       [rawFeature()],
@@ -2040,6 +2475,7 @@ describe('ZoneAlerteService Sandre synchronization', () => {
       state,
       basin: null,
       invalidGeometryCodes: ['3201'],
+      exactAuditBatch: null,
     });
 
     await expect(harness.service.updateDepartementZones('65')).resolves.toEqual(
@@ -2058,6 +2494,10 @@ describe('ZoneAlerteService Sandre synchronization', () => {
       ]),
     );
     expect(harness.zoneRepository.save).not.toHaveBeenCalled();
+    expect(harness.manager.query).not.toHaveBeenCalledWith(
+      expect.stringContaining("batch.mode = 'audit'"),
+      expect.anything(),
+    );
     expect(harness.stateRepository.save).not.toHaveBeenCalled();
     expect(state).toEqual(
       expect.objectContaining({

--- a/apps/backend-admin/src/zone_alerte/zone_alerte.service.ts
+++ b/apps/backend-admin/src/zone_alerte/zone_alerte.service.ts
@@ -37,6 +37,7 @@ import {
   parseGenealogyCsv,
   ReconciliationMapping,
   SANDRE_GENEALOGY_METADATA_URL,
+  SANDRE_GENEALOGY_REQUEST_HEADERS,
   SandreGenealogyRelation,
   ZoneReferenceCounts,
 } from './sandre-zone-reconciliation';
@@ -59,6 +60,28 @@ import {
   normalizeSandreZoneGeometries,
   SandreGeometryAudit,
 } from './sandre-zone-geometry';
+import {
+  fetchSandreMdmNomenclatureEvidence,
+  fetchSandreMdmZoneRecordEvidence,
+  SandreMdmNomenclatureEvidence,
+  SandreMdmTransportResponse,
+  SandreMdmZoneRecordEvidence,
+} from './sandre-mdm-evidence';
+import {
+  applySandreApprovedPartitionReferences,
+  assertSandreApprovedOneToOneApplied,
+  loadSandreApprovedReferenceEvidence,
+  lockSandreApprovedSyncReferences,
+  parseSandreApprovedReferenceEvidence,
+  SandreApprovedReferenceEvidence,
+} from './sandre-zone-sync-approved-references';
+import {
+  assertSandreApprovedMaterializedTargets,
+  auditSandreApprovedSyncGeometry,
+  findSandreApprovedSyncSnapshot,
+  SandreApprovedSyncSnapshot,
+} from './sandre-zone-sync-approvals';
+import { fingerprint } from './sandre-zone-reconciliation';
 
 const SANDRE_FULL_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const SANDRE_HTTP_TIMEOUT_MS = 30 * 1000;
@@ -159,12 +182,43 @@ interface SandreSnapshotApplication {
   stale: boolean;
 }
 
+interface SandreApprovedAuditEvidence {
+  batchId: string;
+  decisions: Map<string, Record<string, unknown>>;
+}
+
+interface SandreApprovedMdmEvidence {
+  approvalId: string;
+  zoneRecords: SandreMdmZoneRecordEvidence[];
+  nomenclature: SandreMdmNomenclatureEvidence | null;
+}
+
+interface SandreApprovedSourceIdentityEvidence {
+  matchType: 'canonical' | 'legacy_gid';
+  idSandre: number;
+  codeSandre: string | null;
+  provenance: 'official' | 'legacy_unverified';
+  disabled: boolean;
+  statutSandre: string | null;
+  dateMajSandre: string | null;
+  numeroVersionSandre: number | null;
+  sandrePayloadHash: string | null;
+}
+
 interface OperationalDisabledZoneSource {
   id: number;
   idSandre: number | null;
   codeSandre: string | null;
   legacyCode: string;
   type: 'SOU' | 'SUP';
+}
+
+interface ReferencedFrozenSandreSource {
+  feature: SandreZoneFeature;
+  matchType: SandreZoneMatch['matchType'];
+  zone: ZoneAlerte;
+  references: ZoneReferenceInventory;
+  operationalReferenceCount: number;
 }
 
 interface ZoneReferenceInventory extends ZoneReferenceCounts {
@@ -755,12 +809,23 @@ export class ZoneAlerteService {
     if (syncMode === 'audit') {
       await this.recordSandreObservation(depCode, snapshot, startedAt);
       try {
+        const approvedSnapshot = findSandreApprovedSyncSnapshot(
+          depCode,
+          snapshot,
+        );
+        const approvedMdmEvidence = approvedSnapshot
+          ? await this.fetchApprovedSandreMdmEvidence(approvedSnapshot)
+          : undefined;
         const preflight = await this.createSandreSnapshotPreflight(
           this.dataSource.manager,
           depCode,
           snapshot,
         );
-        const decisions = await this.createAuditDecisions(snapshot, preflight);
+        const decisions = await this.createAuditDecisions(
+          snapshot,
+          preflight,
+          approvedMdmEvidence,
+        );
         await this.persistSandreDecisions(
           this.dataSource,
           depCode,
@@ -794,11 +859,19 @@ export class ZoneAlerteService {
 
     let application: SandreSnapshotApplication;
     try {
+      const approvedSnapshot = findSandreApprovedSyncSnapshot(
+        depCode,
+        snapshot,
+      );
+      const approvedMdmEvidence = approvedSnapshot
+        ? await this.fetchApprovedSandreMdmEvidence(approvedSnapshot)
+        : undefined;
       application = await this.applySandreSnapshot(
         depCode,
         snapshot,
         startedAt,
         batchId,
+        approvedMdmEvidence,
       );
     } catch (error) {
       const decisions =
@@ -1020,6 +1093,62 @@ export class ZoneAlerteService {
     return { observedDepartmentIds, attemptedDepartmentIds };
   }
 
+  private async loadExactSandreAuditEvidenceForSafe(
+    manager: EntityManager,
+    departmentId: number,
+    snapshot: SandreZoneSnapshot,
+    cutoff: Date,
+  ): Promise<SandreApprovedAuditEvidence> {
+    const [batch] = await manager.query(
+      `
+        SELECT
+          batch.id,
+          batch.status,
+          batch."snapshotHash",
+          batch."sourceUpdatedAt"::text AS "sourceUpdatedAt",
+          batch."featureCount"
+        FROM sandre_zone_sync_batch batch
+        WHERE batch."departementId" = $1
+          AND batch.kind = 'snapshot'
+          AND batch.mode = 'audit'
+          AND batch."startedAt" >= $2
+        ORDER BY batch."startedAt" DESC, batch.id DESC
+        LIMIT 1
+        FOR SHARE
+      `,
+      [departmentId, cutoff],
+    );
+    if (
+      !batch ||
+      batch.status !== 'observed' ||
+      batch.snapshotHash !== snapshot.snapshotHash ||
+      batch.sourceUpdatedAt !== snapshot.sourceUpdatedAt ||
+      Number(batch.featureCount) !== snapshot.featureCount
+    ) {
+      throw new Error(
+        'SANDRE safe mode requires a successful exact-snapshot audit',
+      );
+    }
+    const rows = await manager.query(
+      `
+        SELECT "decisionKey", evidence
+        FROM sandre_zone_sync_decision
+        WHERE "batchId" = $1
+        ORDER BY "decisionKey"
+      `,
+      [batch.id],
+    );
+    return {
+      batchId: String(batch.id),
+      decisions: new Map(
+        rows.map((row) => [
+          String(row.decisionKey),
+          (row.evidence ?? {}) as Record<string, unknown>,
+        ]),
+      ),
+    };
+  }
+
   private assertSafeRolloutAuditComplete(
     departements: Array<{ id: number; code: string }>,
     observedDepartmentIds: Set<number>,
@@ -1166,6 +1295,12 @@ export class ZoneAlerteService {
     const normalizedGeometry = await normalizeSandreZoneGeometries(
       manager,
       rawActiveFeatures,
+      {
+        departmentCode: depCode,
+        snapshotHash: snapshot.snapshotHash,
+        sourceUpdatedAt: snapshot.sourceUpdatedAt,
+        featureCount: snapshot.featureCount,
+      },
     );
     const activeFeatures = normalizedGeometry.features;
 
@@ -1311,6 +1446,7 @@ export class ZoneAlerteService {
   private async createAuditDecisions(
     snapshot: SandreZoneSnapshot,
     preflight: SandreSnapshotPreflight,
+    approvedMdmEvidence?: SandreApprovedMdmEvidence,
   ): Promise<SandreSyncDecisionDraft[]> {
     const decisions: SandreSyncDecisionDraft[] = snapshot.features.map(
       (feature) =>
@@ -1400,6 +1536,10 @@ export class ZoneAlerteService {
         activeZonesByCode,
         decisions,
         false,
+        undefined,
+        undefined,
+        undefined,
+        approvedMdmEvidence,
       );
     } catch (error) {
       if (error instanceof SandreDepartmentBlockedError) {
@@ -1569,10 +1709,11 @@ export class ZoneAlerteService {
     snapshot: SandreZoneSnapshot,
     snapshotStartedAt: Date,
     batchId: string | null = null,
+    approvedMdmEvidence?: SandreApprovedMdmEvidence,
   ): Promise<SandreSnapshotApplication> {
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
-    await queryRunner.startTransaction();
+    await queryRunner.startTransaction('SERIALIZABLE');
 
     try {
       const departementRepository =
@@ -1589,7 +1730,6 @@ export class ZoneAlerteService {
         "SELECT pg_advisory_xact_lock(hashtext('vigieau:sandre-zone-sync'), $1)",
         [departement.id],
       );
-
       let state = await stateRepository.findOne({
         where: {
           departement: {
@@ -1642,6 +1782,14 @@ export class ZoneAlerteService {
           stale: true,
         };
       }
+
+      const approvedAuditEvidence =
+        await this.loadExactSandreAuditEvidenceForSafe(
+          queryRunner.manager,
+          departement.id,
+          snapshot,
+          this.getRequiredSandreAuditCutoff('safe'),
+        );
 
       const result: SandreSyncResult = {
         added: 0,
@@ -1744,6 +1892,8 @@ export class ZoneAlerteService {
           true,
           operationalDisabledSources,
           genealogyLoad,
+          approvedAuditEvidence,
+          approvedMdmEvidence,
         );
       recomputeRequired ||= operationalReferencesReconciled;
 
@@ -1778,6 +1928,8 @@ export class ZoneAlerteService {
           missingVerifiedIdentity ||
           zone.statutSandre !== feature.status ||
           zone.dateMajSandre !== feature.sourceUpdatedAt ||
+          zone.numeroVersionSandre !== feature.version ||
+          !sameStringArrays(zone.codesAlternatifs, feature.alternateCodes) ||
           zone.sandrePayloadHash !== feature.payloadHash;
         if (!changed) {
           result.unchanged++;
@@ -1796,11 +1948,13 @@ export class ZoneAlerteService {
         zone.disabled = true;
         zone.statutSandre = feature.status;
         zone.dateMajSandre = feature.sourceUpdatedAt;
+        zone.numeroVersionSandre = feature.version;
         zone.codesAlternatifs = feature.alternateCodes;
         zone.sandrePayloadHash = feature.payloadHash;
         if (missingVerifiedIdentity) {
           zone.idSandre = feature.gid;
           zone.codeSandre = feature.codeSandre;
+          zone.sandreProvenance = 'official';
         }
         await queryRunner.manager.getRepository(ZoneAlerte).save(zone);
         result.disabled++;
@@ -1932,6 +2086,8 @@ export class ZoneAlerteService {
     apply = true,
     operationalDisabledSources?: OperationalDisabledZoneSource[],
     genealogyLoad?: SandreGenealogyLoad,
+    approvedAuditEvidence?: SandreApprovedAuditEvidence,
+    approvedMdmEvidence?: SandreApprovedMdmEvidence,
   ): Promise<boolean> {
     const resolvedInactiveZoneIds = new Set(
       resolvedInactiveFeatures.flatMap(({ match }) =>
@@ -1965,13 +2121,7 @@ export class ZoneAlerteService {
       );
     }
 
-    let referencedSources: Array<{
-      feature: SandreZoneFeature;
-      matchType: SandreZoneMatch['matchType'];
-      zone: ZoneAlerte;
-      references: ZoneReferenceInventory;
-      operationalReferenceCount: number;
-    }> = [];
+    let referencedSources: ReferencedFrozenSandreSource[] = [];
 
     for (const { feature, match } of resolvedInactiveFeatures) {
       if (!match || activeZoneIds.has(match.zone.id)) {
@@ -2063,8 +2213,35 @@ export class ZoneAlerteService {
       (source) => !unverifiedSourceIds.has(source.zone.id),
     );
 
+    let approvedReferencesReconciled = false;
+    const approvedSnapshot = findSandreApprovedSyncSnapshot(
+      departement.code,
+      snapshot,
+    );
+    if (approvedSnapshot) {
+      approvedReferencesReconciled =
+        await this.reconcileApprovedSandreSnapshotMappings(
+          manager,
+          departement,
+          snapshot,
+          approvedSnapshot,
+          resolvedInactiveFeatures,
+          activeZonesByCode,
+          decisions,
+          apply,
+          approvedAuditEvidence,
+          approvedMdmEvidence,
+        );
+      const approvedCodes = new Set(
+        approvedSnapshot.mappings.map((mapping) => mapping.sourceCode),
+      );
+      referencedSources = referencedSources.filter(
+        (source) => !approvedCodes.has(source.feature.codeSandre),
+      );
+    }
+
     if (referencedSources.length === 0) {
-      return false;
+      return approvedReferencesReconciled;
     }
 
     let relations: SandreGenealogyRelation[];
@@ -2393,7 +2570,9 @@ export class ZoneAlerteService {
         },
       });
     }
-    return apply && operationalReferencesReconciled;
+    return (
+      approvedReferencesReconciled || (apply && operationalReferencesReconciled)
+    );
   }
 
   private async getOperationalDisabledZoneSources(
@@ -2453,6 +2632,527 @@ export class ZoneAlerteService {
       legacyCode: String(row.legacyCode),
       type: row.type as 'SOU' | 'SUP',
     }));
+  }
+
+  private async reconcileApprovedSandreSnapshotMappings(
+    manager: EntityManager,
+    departement: Departement,
+    snapshot: SandreZoneSnapshot,
+    approval: SandreApprovedSyncSnapshot,
+    resolvedInactiveFeatures: Array<{
+      feature: SandreZoneFeature;
+      match: SandreZoneMatch | null;
+    }>,
+    activeZonesByCode: Map<string, ZoneAlerte>,
+    decisions: SandreSyncDecisionDraft[],
+    apply: boolean,
+    approvedAuditEvidence?: SandreApprovedAuditEvidence,
+    approvedMdmEvidence?: SandreApprovedMdmEvidence,
+  ): Promise<boolean> {
+    if (apply && !approvedAuditEvidence) {
+      throw new Error('Missing exact Sandre audit evidence for safe mode');
+    }
+    const inactiveByCode = new Map(
+      resolvedInactiveFeatures.map((item) => [item.feature.codeSandre, item]),
+    );
+    const featuresByCode = new Map(
+      snapshot.features.map((feature) => [feature.codeSandre, feature]),
+    );
+    const resolved = approval.mappings.map((mapping) => {
+      const source = inactiveByCode.get(mapping.sourceCode);
+      const targets = mapping.targetCodes.map((codeSandre) => ({
+        feature: featuresByCode.get(codeSandre),
+        zone: activeZonesByCode.get(codeSandre),
+      }));
+      const canonicalSourceIdentity =
+        source?.match?.matchType === 'canonical' &&
+        source.match.zone.codeSandre === source.feature.codeSandre &&
+        source.match.zone.sandreProvenance === 'official';
+      const legacySourceIdentity =
+        source?.match?.matchType === 'legacy_gid' &&
+        source.match.zone.codeSandre === null &&
+        source.match.zone.idSandre === source.feature.gid &&
+        source.match.zone.sandreProvenance === 'legacy_unverified';
+      if (
+        !source?.match ||
+        source.match.zone.id !== mapping.sourceZoneId ||
+        source.feature.status !== 'Gelé' ||
+        source.feature.type !== 'SUP' ||
+        source.match.zone.idSandre !== source.feature.gid ||
+        (!canonicalSourceIdentity && !legacySourceIdentity) ||
+        source.match.zone.type !== source.feature.type ||
+        targets.some(
+          (target) =>
+            !target.feature ||
+            !target.zone ||
+            target.feature.status !== 'Validé' ||
+            target.feature.type !== source.feature.type ||
+            target.zone.idSandre !== target.feature.gid ||
+            target.zone.codeSandre !== target.feature.codeSandre,
+        )
+      ) {
+        throw new SandreDepartmentBlockedError(
+          `Approved Sandre mapping identity changed for ${mapping.sourceCode}`,
+        );
+      }
+      return {
+        mapping,
+        source: source as {
+          feature: SandreZoneFeature;
+          match: SandreZoneMatch;
+        },
+        targets: targets as Array<{
+          feature: SandreZoneFeature;
+          zone: ZoneAlerte;
+        }>,
+      };
+    });
+
+    if (
+      !approvedMdmEvidence ||
+      approvedMdmEvidence.approvalId !== approval.approvalId
+    ) {
+      throw new SandreDepartmentBlockedError(
+        `Missing preloaded MDM evidence for ${approval.approvalId}`,
+      );
+    }
+    if (apply) {
+      await lockSandreApprovedSyncReferences(
+        manager,
+        resolved.map((item) => item.source.match.zone.id),
+        resolved.flatMap((item) =>
+          item.targets
+            .map((target) => target.zone.id)
+            .filter((id) => Number.isInteger(id) && id > 0),
+        ),
+      );
+      await assertSandreApprovedMaterializedTargets(
+        manager,
+        departement.id,
+        resolved.flatMap((item) =>
+          item.targets.map((target) => ({
+            feature: target.feature,
+            zoneAlerteId: target.zone.id,
+          })),
+        ),
+      );
+    }
+    const stableMdmEvidence = approvedMdmEvidence.zoneRecords.map((record) => ({
+      codeSandre: record.codeSandre,
+      projection: record.projection,
+      projectionSha256: record.projectionSha256,
+      requiredEvolution: record.requiredEvolution,
+    }));
+    const stableMdmNomenclature = approvedMdmEvidence.nomenclature
+      ? {
+          projection: approvedMdmEvidence.nomenclature.projection,
+          projectionSha256: approvedMdmEvidence.nomenclature.projectionSha256,
+        }
+      : null;
+
+    let referencesReconciled = false;
+    for (const item of resolved) {
+      const targetZoneIds = item.targets.map((target) => target.zone.id);
+      const geometry = await auditSandreApprovedSyncGeometry(
+        manager,
+        item.mapping,
+        item.targets.map((target) => target.feature),
+      );
+      const observedSourceIdentity: SandreApprovedSourceIdentityEvidence = {
+        matchType:
+          item.source.match.matchType === 'canonical'
+            ? 'canonical'
+            : 'legacy_gid',
+        idSandre: item.source.match.zone.idSandre!,
+        codeSandre: item.source.match.zone.codeSandre ?? null,
+        provenance: item.source.match.zone.sandreProvenance as
+          | 'official'
+          | 'legacy_unverified',
+        disabled: item.source.match.zone.disabled,
+        statutSandre: item.source.match.zone.statutSandre ?? null,
+        dateMajSandre: item.source.match.zone.dateMajSandre ?? null,
+        numeroVersionSandre: item.source.match.zone.numeroVersionSandre ?? null,
+        sandrePayloadHash: item.source.match.zone.sandrePayloadHash ?? null,
+      };
+      const staticEvidence = {
+        approvalId: approval.approvalId,
+        snapshotHash: approval.snapshotHash,
+        sourceUpdatedAt: approval.sourceUpdatedAt,
+        featureCount: approval.featureCount,
+        featureEvidenceFingerprint: approval.featureEvidenceFingerprint,
+        sourceCode: item.mapping.sourceCode,
+        sourceZoneId: item.mapping.sourceZoneId,
+        sourceIdentityPolicy: 'canonical_or_strict_legacy_gid',
+        mapping: item.mapping,
+        geometry,
+        mdmRecords: stableMdmEvidence,
+        mdmNomenclature: stableMdmNomenclature,
+      };
+      const staticFingerprint = fingerprint(staticEvidence);
+      const decisionKey = `${item.mapping.sourceCode}:approved-snapshot`;
+      let expectedReferences: SandreApprovedReferenceEvidence;
+      let migrationLineage: SandreApprovedReferenceEvidence | undefined;
+      let currentReferences: SandreApprovedReferenceEvidence;
+      let alreadyApplied = false;
+      let auditedSourceIdentity = observedSourceIdentity;
+
+      if (apply) {
+        const audited = approvedAuditEvidence!.decisions.get(decisionKey);
+        if (
+          audited?.approvalId !== approval.approvalId ||
+          audited?.staticFingerprint !== staticFingerprint ||
+          audited?.approvalFingerprint !==
+            fingerprint({
+              staticFingerprint,
+              referenceEvidence: audited?.referenceEvidence,
+              migrationLineage: audited?.migrationLineage ?? null,
+              observedSourceIdentity: audited?.observedSourceIdentity,
+            })
+        ) {
+          throw new SandreDepartmentBlockedError(
+            `Approved Sandre audit evidence changed for ${item.mapping.sourceCode}`,
+          );
+        }
+        expectedReferences = parseSandreApprovedReferenceEvidence(
+          audited.referenceEvidence,
+        );
+        migrationLineage = audited.migrationLineage
+          ? parseSandreApprovedReferenceEvidence(audited.migrationLineage)
+          : undefined;
+        currentReferences = await loadSandreApprovedReferenceEvidence(
+          manager,
+          item.source.match.zone.id,
+          targetZoneIds,
+          migrationLineage ??
+            (expectedReferences.lifecycle === 'pre_apply'
+              ? expectedReferences
+              : undefined),
+        );
+        auditedSourceIdentity = parseSandreApprovedSourceIdentityEvidence(
+          audited.observedSourceIdentity,
+        );
+        const sourceZone = item.source.match.zone;
+        if (
+          currentReferences.fingerprint === expectedReferences.fingerprint &&
+          (sourceZone.idSandre !== item.source.feature.gid ||
+            sourceZone.codeSandre !== item.source.feature.codeSandre ||
+            sourceZone.sandreProvenance !== 'official')
+        ) {
+          sourceZone.idSandre = item.source.feature.gid;
+          sourceZone.codeSandre = item.source.feature.codeSandre;
+          sourceZone.sandreProvenance = 'official';
+          await manager.getRepository(ZoneAlerte).save(sourceZone);
+        }
+        if (currentReferences.fingerprint === expectedReferences.fingerprint) {
+          if (
+            fingerprint(observedSourceIdentity) !==
+            fingerprint(auditedSourceIdentity)
+          ) {
+            throw new SandreDepartmentBlockedError(
+              `Approved Sandre source identity changed for ${item.mapping.sourceCode}`,
+            );
+          }
+          if (expectedReferences.lifecycle === 'post_apply') {
+            if (item.targets.length === 1) {
+              await this.assertSandreApprovedAlias(
+                manager,
+                departement,
+                item.targets[0].zone,
+                item.source.feature.codeSandre,
+              );
+            }
+            alreadyApplied = true;
+          }
+        } else {
+          try {
+            if (expectedReferences.lifecycle !== 'pre_apply') {
+              throw new Error('approved post-apply evidence drifted');
+            }
+            if (
+              item.source.match.zone.idSandre !== item.source.feature.gid ||
+              item.source.match.zone.codeSandre !==
+                item.source.feature.codeSandre
+            ) {
+              throw new Error('approved source identity is not canonical');
+            }
+            if (currentReferences.lifecycle !== 'post_apply') {
+              throw new Error('approved pre-apply state drifted');
+            }
+            this.assertSandreApprovedSourcePostState(
+              item.source.match.zone,
+              item.source.feature,
+            );
+            if (item.targets.length === 1) {
+              await this.assertSandreApprovedAlias(
+                manager,
+                departement,
+                item.targets[0].zone,
+                item.source.feature.codeSandre,
+              );
+            }
+            alreadyApplied = true;
+          } catch (error) {
+            throw new SandreDepartmentBlockedError(
+              `Approved Sandre state drifted for ${item.mapping.sourceCode}: ${this.sandreFailureReason(error)}`,
+            );
+          }
+        }
+      } else {
+        migrationLineage = await this.loadLatestAppliedSandreMigrationLineage(
+          manager,
+          departement.id,
+          decisionKey,
+          approval.approvalId,
+        );
+        currentReferences = await loadSandreApprovedReferenceEvidence(
+          manager,
+          item.source.match.zone.id,
+          targetZoneIds,
+          migrationLineage,
+        );
+        expectedReferences = currentReferences;
+        if (
+          currentReferences.lifecycle === 'post_apply' &&
+          item.targets.length === 1
+        ) {
+          await this.assertSandreApprovedAlias(
+            manager,
+            departement,
+            item.targets[0].zone,
+            item.source.feature.codeSandre,
+          );
+        }
+      }
+
+      if (apply && !alreadyApplied) {
+        const sourceZone = item.source.match.zone;
+        if (
+          sourceZone.idSandre !== item.source.feature.gid ||
+          sourceZone.codeSandre !== item.source.feature.codeSandre ||
+          sourceZone.sandreProvenance !== 'official'
+        ) {
+          sourceZone.idSandre = item.source.feature.gid;
+          sourceZone.codeSandre = item.source.feature.codeSandre;
+          sourceZone.sandreProvenance = 'official';
+          await manager.getRepository(ZoneAlerte).save(sourceZone);
+        }
+        if (item.targets.length === 1) {
+          const targetZone = item.targets[0].zone;
+          const mapping: ReconciliationMapping = {
+            departmentId: departement.id,
+            departmentCode: departement.code,
+            zoneType: item.source.feature.type,
+            oldZoneId: sourceZone.id,
+            oldCodeSandre: item.source.feature.codeSandre,
+            newZoneId: targetZone.id,
+            newCodeSandre: item.targets[0].feature.codeSandre,
+          };
+          await this.assertNoOperationalReferenceCollision(manager, mapping);
+          await this.ensureSandreAlias(
+            manager,
+            departement,
+            targetZone,
+            item.source.feature.codeSandre,
+            'sandre_genealogy',
+            sourceZone.id,
+          );
+          if (
+            expectedReferences.arreteCadreLinks.length > 0 ||
+            expectedReferences.restrictions.length > 0 ||
+            expectedReferences.customizationCount > 0
+          ) {
+            await manager.query(
+              'SELECT remap_operational_sandre_zone_references($1, $2)',
+              [sourceZone.id, targetZone.id],
+            );
+            await assertSandreApprovedOneToOneApplied(
+              manager,
+              expectedReferences,
+              targetZone.id,
+            );
+            referencesReconciled = true;
+          }
+        } else {
+          const result = await applySandreApprovedPartitionReferences(
+            manager,
+            expectedReferences,
+            item.targets.map((target) => ({
+              codeSandre: target.feature.codeSandre,
+              zoneAlerteId: target.zone.id,
+            })),
+            item.mapping.effectiveDate!,
+          );
+          referencesReconciled ||= result.applied;
+        }
+      }
+
+      if (apply && !migrationLineage) {
+        migrationLineage = await loadSandreApprovedReferenceEvidence(
+          manager,
+          item.source.match.zone.id,
+          targetZoneIds,
+          expectedReferences,
+        );
+      }
+
+      const approvalFingerprint = fingerprint({
+        staticFingerprint,
+        referenceEvidence: expectedReferences,
+        migrationLineage: migrationLineage ?? null,
+        observedSourceIdentity: auditedSourceIdentity,
+      });
+      decisions.push({
+        decisionKey,
+        zoneType: item.source.feature.type,
+        sourceCode: item.mapping.sourceCode,
+        targetCode: item.mapping.targetCodes.join(','),
+        zoneAlerteId: item.source.match.zone.id,
+        candidateZoneAlerteId:
+          item.targets.length === 1 && item.targets[0].zone.id > 0
+            ? item.targets[0].zone.id
+            : null,
+        action: 'RECONCILE_APPROVED_SNAPSHOT',
+        outcome: apply ? 'applied' : 'observed',
+        reason: alreadyApplied
+          ? 'APPROVED_MAPPING_ALREADY_APPLIED'
+          : 'APPROVED_EXACT_SNAPSHOT_MAPPING',
+        evidence: {
+          approvalId: approval.approvalId,
+          approvedAuditBatchId: approvedAuditEvidence?.batchId ?? null,
+          staticFingerprint,
+          referenceEvidence: expectedReferences,
+          migrationLineage: migrationLineage ?? null,
+          observedSourceIdentity: auditedSourceIdentity,
+          approvalFingerprint,
+          mdmTransportEvidence: approvedMdmEvidence,
+        },
+      });
+    }
+    return apply && referencesReconciled;
+  }
+
+  private async loadLatestAppliedSandreMigrationLineage(
+    manager: EntityManager,
+    departmentId: number,
+    decisionKey: string,
+    approvalId: string,
+  ): Promise<SandreApprovedReferenceEvidence | undefined> {
+    const [row] = await manager.query(
+      `
+        SELECT decision.evidence -> 'migrationLineage' AS lineage
+        FROM sandre_zone_sync_decision decision
+        JOIN sandre_zone_sync_batch batch ON batch.id = decision."batchId"
+        WHERE decision."departementId" = $1
+          AND decision."decisionKey" = $2
+          AND decision.action = 'RECONCILE_APPROVED_SNAPSHOT'
+          AND decision.outcome = 'applied'
+          AND batch.mode = 'safe'
+          AND batch.status IN ('started', 'applied')
+          AND decision.evidence ->> 'approvalId' = $3
+          AND decision.evidence ? 'migrationLineage'
+        ORDER BY batch."startedAt" DESC, batch.id DESC
+        LIMIT 1
+      `,
+      [departmentId, decisionKey, approvalId],
+    );
+    return row?.lineage
+      ? parseSandreApprovedReferenceEvidence(row.lineage)
+      : undefined;
+  }
+
+  private async fetchApprovedSandreMdmEvidence(
+    approval: SandreApprovedSyncSnapshot,
+  ): Promise<SandreApprovedMdmEvidence> {
+    const zoneRecords = await Promise.all(
+      approval.mdmRecords.map((expectation) =>
+        fetchSandreMdmZoneRecordEvidence(expectation, (url) =>
+          this.fetchSandreMdmTransport(
+            url,
+            'application/json',
+            2 * 1024 * 1024,
+          ),
+        ),
+      ),
+    );
+    const nomenclature = approval.mdmNomenclature
+      ? await fetchSandreMdmNomenclatureEvidence(
+          approval.mdmNomenclature,
+          (url) =>
+            this.fetchSandreMdmTransport(
+              url,
+              'text/html,application/xhtml+xml;q=0.9',
+              512 * 1024,
+            ),
+        )
+      : null;
+    return { approvalId: approval.approvalId, zoneRecords, nomenclature };
+  }
+
+  private async fetchSandreMdmTransport(
+    url: string,
+    accept: string,
+    maximumBytes: number,
+  ): Promise<SandreMdmTransportResponse> {
+    const attempts = 3;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        const response = await firstValueFrom(
+          this.httpService.get(url, {
+            headers: { accept, 'accept-language': 'fr' },
+            responseType: 'text',
+            timeout: 60_000,
+            maxRedirects: 0,
+            maxContentLength: maximumBytes,
+            maxBodyLength: maximumBytes,
+            transformResponse: [(body) => body],
+            validateStatus: () => true,
+          }),
+        );
+        if (
+          attempt < attempts &&
+          (response.status === 429 || response.status >= 500)
+        ) {
+          await this.waitForSandreMdmRetry(attempt);
+          continue;
+        }
+        return {
+          status: response.status,
+          contentType:
+            typeof response.headers?.['content-type'] === 'string'
+              ? response.headers['content-type']
+              : null,
+          finalUrl:
+            response.request?.res?.responseUrl ??
+            response.request?.responseURL ??
+            url,
+          body: typeof response.data === 'string' ? response.data : '',
+        };
+      } catch (error) {
+        const code =
+          error && typeof error === 'object' && 'code' in error
+            ? String(error.code)
+            : '';
+        if (
+          attempt === attempts ||
+          ![
+            'ECONNABORTED',
+            'ECONNRESET',
+            'ECONNREFUSED',
+            'EAI_AGAIN',
+            'ENETUNREACH',
+            'ETIMEDOUT',
+          ].includes(code)
+        ) {
+          throw error;
+        }
+        await this.waitForSandreMdmRetry(attempt);
+      }
+    }
+    throw new Error('Sandre MDM retry budget exhausted');
+  }
+
+  private async waitForSandreMdmRetry(attempt: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, attempt * 100));
   }
 
   private async lockOperationalParentsForSandreSources(
@@ -2613,6 +3313,7 @@ export class ZoneAlerteService {
   > {
     const { data: metadata } = await firstValueFrom(
       this.httpService.get(SANDRE_GENEALOGY_METADATA_URL, {
+        headers: SANDRE_GENEALOGY_REQUEST_HEADERS,
         responseType: 'text',
         timeout: SANDRE_HTTP_TIMEOUT_MS,
         maxContentLength: SANDRE_GENEALOGY_METADATA_MAX_BYTES,
@@ -2625,6 +3326,7 @@ export class ZoneAlerteService {
     );
     const { data: csv } = await firstValueFrom(
       this.httpService.get(csvUrl, {
+        headers: SANDRE_GENEALOGY_REQUEST_HEADERS,
         responseType: 'text',
         timeout: SANDRE_HTTP_TIMEOUT_MS,
         maxContentLength: SANDRE_GENEALOGY_CSV_MAX_BYTES,
@@ -2894,6 +3596,48 @@ export class ZoneAlerteService {
     );
   }
 
+  private async assertSandreApprovedAlias(
+    manager: EntityManager,
+    departement: Departement,
+    zone: ZoneAlerte,
+    aliasValue: string,
+  ): Promise<void> {
+    const aliases = await manager.getRepository(SandreZoneAlias).find({
+      where: {
+        departement: { id: departement.id },
+        zoneAlerte: { id: zone.id },
+        zoneType: zone.type,
+        aliasType: 'cd_zas',
+        aliasValue,
+      },
+      take: 2,
+    });
+    if (aliases.length !== 1) {
+      throw new Error(`Approved Sandre alias ${aliasValue} changed`);
+    }
+  }
+
+  private assertSandreApprovedSourcePostState(
+    zone: ZoneAlerte,
+    feature: SandreZoneFeature,
+  ): void {
+    if (
+      zone.disabled !== true ||
+      zone.idSandre !== feature.gid ||
+      zone.codeSandre !== feature.codeSandre ||
+      zone.sandreProvenance !== 'official' ||
+      zone.statutSandre !== feature.status ||
+      zone.dateMajSandre !== feature.sourceUpdatedAt ||
+      zone.numeroVersionSandre !== feature.version ||
+      zone.sandrePayloadHash !== feature.payloadHash ||
+      !sameStringArrays(zone.codesAlternatifs, feature.alternateCodes)
+    ) {
+      throw new Error(
+        `Approved Sandre source ${feature.codeSandre} post-state changed`,
+      );
+    }
+  }
+
   private async recomputeSandreDepartment(depCode: string): Promise<void> {
     const departement = await this.dataSource
       .getRepository(Departement)
@@ -2997,4 +3741,48 @@ export class ZoneAlerteService {
 
     return result[0]?.combined_geom;
   }
+}
+
+function parseSandreApprovedSourceIdentityEvidence(
+  value: unknown,
+): SandreApprovedSourceIdentityEvidence {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid approved Sandre source identity evidence');
+  }
+  const row = value as Record<string, unknown>;
+  const parsed: SandreApprovedSourceIdentityEvidence = {
+    matchType: row.matchType as 'canonical' | 'legacy_gid',
+    idSandre: Number(row.idSandre),
+    codeSandre: row.codeSandre === null ? null : String(row.codeSandre),
+    provenance: row.provenance as 'official' | 'legacy_unverified',
+    disabled: row.disabled as boolean,
+    statutSandre: row.statutSandre === null ? null : String(row.statutSandre),
+    dateMajSandre:
+      row.dateMajSandre === null ? null : String(row.dateMajSandre),
+    numeroVersionSandre:
+      row.numeroVersionSandre === null ? null : Number(row.numeroVersionSandre),
+    sandrePayloadHash:
+      row.sandrePayloadHash === null ? null : String(row.sandrePayloadHash),
+  };
+  if (
+    !['canonical', 'legacy_gid'].includes(parsed.matchType) ||
+    !Number.isInteger(parsed.idSandre) ||
+    parsed.idSandre <= 0 ||
+    typeof row.disabled !== 'boolean' ||
+    (parsed.matchType === 'canonical'
+      ? parsed.provenance !== 'official' ||
+        !/^\d{1,32}$/.test(parsed.codeSandre ?? '')
+      : parsed.provenance !== 'legacy_unverified' ||
+        parsed.codeSandre !== null) ||
+    (parsed.dateMajSandre !== null &&
+      !/^\d{4}-\d{2}-\d{2}$/.test(parsed.dateMajSandre)) ||
+    (parsed.numeroVersionSandre !== null &&
+      !Number.isInteger(parsed.numeroVersionSandre)) ||
+    (parsed.sandrePayloadHash !== null &&
+      !/^[a-f0-9]{64}$/.test(parsed.sandrePayloadHash)) ||
+    fingerprint(parsed) !== fingerprint(value)
+  ) {
+    throw new Error('Invalid approved Sandre source identity evidence');
+  }
+  return parsed;
 }


### PR DESCRIPTION
## Contexte

Le dry-run PROD complet a révélé quatre blocages fail-closed dans les départements 11, 24, 49 et 85. Les causes étaient distinctes : normalisations géométriques officielles au-dessus du seuil global, métadonnées de généalogie servies dans un format inattendu, doublon legacy exact et transitions 2026 absentes du CSV de généalogie publié.

## Changements

- approuve exactement les huit normalisations du snapshot officiel du 11, avec hashes brut/normalisé, topologie, comptages et bornes par feature ;
- ajoute un plan audité séparé pour le doublon exact 16677 -> 9708 dans le 49 ;
- scelle les snapshots/mappings 24 et 85, matérialise les cibles pendant le safe et lie audit/safe par snapshot, géométrie, identité, références et lineage ;
- précharge les preuves MDM hors transaction avec transport borné, retry transitoire et validation de la nomenclature officielle ;
- migre uniquement les références opérationnelles, conserve les IDs et dérivés historiques, pose la dette à la date effective et rend le replay idempotent ;
- passe les rapports d’opération en version 4 afin de rejeter explicitement les anciens dry-runs.

## Validation

- Node 20.18.1 : build, 72 suites / 1 036 tests ;
- Node 24.16.0 : build, 72 suites / 1 036 tests ;
- PostgreSQL/PostGIS réel : 9/9 ;
- tests ciblés : 134/134 ;
- ESLint des fichiers modifiés, Prettier et `git diff --check` : OK.

## Rollout

Un nouvel audit exact des 101 départements est obligatoire après déploiement. Le safe reste fail-closed tant que la preuve MDM officielle n’est pas disponible ; aucun ancien rapport v3 ne peut être réutilisé.