### PR TITLE
fix(admin): bound SANDRE MDM evidence retries

### DIFF
--- a/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.spec.ts
@@ -2,10 +2,13 @@ import { fingerprint } from './sandre-zone-reconciliation';
 import {
   fetchSandreMdmNomenclatureEvidence,
   fetchSandreMdmZoneRecordEvidence,
+  loadSandreMdmProofWithRetry,
   projectSandreMdmNomenclatureNode,
   projectSandreMdmZoneRecord,
   SANDRE_MDM_MAX_ZONE_RECORD_BYTES,
   SANDRE_MDM_ZONE_RECORD_BASE_URL,
+  SandreMdmProofDeadlineExceededError,
+  SandreMdmTransientError,
   SandreMdmTransportResponse,
 } from './sandre-mdm-evidence';
 
@@ -209,6 +212,197 @@ describe('Sandre MDM split evidence', () => {
         '590',
       ),
     ).toThrow('root');
+  });
+
+  it('restarts the complete proof after a transient failure and recovers', async () => {
+    const completedReads: string[] = [];
+    let attempt = 0;
+    const loadProof = jest.fn(async () => {
+      attempt++;
+      completedReads.push(`${attempt}:355`, `${attempt}:3947`);
+      if (attempt === 1) {
+        throw new SandreMdmTransientError('HTTP 500 for 3947');
+      }
+      completedReads.push(`${attempt}:3948`, `${attempt}:282836`);
+      return 'complete-proof';
+    });
+    const waitForRetry = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      loadSandreMdmProofWithRetry(loadProof, waitForRetry, {
+        attempts: 3,
+      }),
+    ).resolves.toBe('complete-proof');
+    expect(loadProof).toHaveBeenCalledTimes(2);
+    expect(waitForRetry).toHaveBeenCalledTimes(1);
+    expect(waitForRetry).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ expiresAt: expect.any(Number) }),
+    );
+    expect(completedReads).toEqual([
+      '1:355',
+      '1:3947',
+      '2:355',
+      '2:3947',
+      '2:3948',
+      '2:282836',
+    ]);
+  });
+
+  it('fails closed after exhausting the transient proof retry budget', async () => {
+    const transient = new SandreMdmTransientError('HTTP 500');
+    const loadProof = jest.fn().mockRejectedValue(transient);
+    const waitForRetry = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      loadSandreMdmProofWithRetry(loadProof, waitForRetry, {
+        attempts: 3,
+      }),
+    ).rejects.toMatchObject({
+      message: 'Sandre MDM proof retry budget exhausted after 3 attempts',
+      cause: transient,
+    });
+    expect(loadProof).toHaveBeenCalledTimes(3);
+    expect(waitForRetry.mock.calls.map(([attempt]) => attempt)).toEqual([1, 2]);
+  });
+
+  it('does not retry validation drift', async () => {
+    const validationError = new Error(
+      'Sandre MDM projection changed for zone 3947',
+    );
+    const loadProof = jest.fn().mockRejectedValue(validationError);
+    const waitForRetry = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      loadSandreMdmProofWithRetry(loadProof, waitForRetry, {
+        attempts: 5,
+      }),
+    ).rejects.toBe(validationError);
+    expect(loadProof).toHaveBeenCalledTimes(1);
+    expect(waitForRetry).not.toHaveBeenCalled();
+  });
+
+  it('enforces one monotonic deadline across proof attempts and backoffs', async () => {
+    let now = 1_000;
+    const transient = new SandreMdmTransientError('HTTP 500');
+    const loadProof = jest.fn(async () => {
+      now += 40;
+      throw transient;
+    });
+    const waitForRetry = jest.fn(async () => {
+      now += 20;
+    });
+
+    await expect(
+      loadSandreMdmProofWithRetry(loadProof, waitForRetry, {
+        attempts: 5,
+        timeoutMs: 100,
+        now: () => now,
+      }),
+    ).rejects.toMatchObject({
+      name: 'SandreMdmProofDeadlineExceededError',
+      cause: transient,
+    });
+    expect(loadProof).toHaveBeenCalledTimes(2);
+    expect(waitForRetry).toHaveBeenCalledTimes(1);
+    expect(now).toBe(1_100);
+  });
+
+  it('actively cancels a retried proof at one wall-clock deadline', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-16T12:00:00.000Z'));
+    try {
+      let attempt = 0;
+      const observedSignals: AbortSignal[] = [];
+      const cancellation = jest.fn();
+      const transient = new SandreMdmTransientError('HTTP 500');
+      const loadProof = jest.fn(
+        (budget: { signal: AbortSignal }): Promise<string> => {
+          attempt++;
+          observedSignals.push(budget.signal);
+          if (attempt === 1) {
+            return Promise.reject(transient);
+          }
+          return new Promise((_resolve, reject) => {
+            budget.signal.addEventListener(
+              'abort',
+              () => {
+                cancellation();
+                reject(budget.signal.reason);
+              },
+              { once: true },
+            );
+          });
+        },
+      );
+      const waitForRetry = jest.fn().mockResolvedValue(undefined);
+      const proof = loadSandreMdmProofWithRetry(loadProof, waitForRetry, {
+        attempts: 3,
+        timeoutMs: 100,
+        now: () => Date.now(),
+      });
+      const rejection = expect(proof).rejects.toBeInstanceOf(
+        SandreMdmProofDeadlineExceededError,
+      );
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(loadProof).toHaveBeenCalledTimes(2);
+      expect(waitForRetry).toHaveBeenCalledTimes(1);
+      expect(observedSignals[0]).toBe(observedSignals[1]);
+      expect(jest.getTimerCount()).toBe(1);
+
+      await jest.advanceTimersByTimeAsync(99);
+      expect(cancellation).not.toHaveBeenCalled();
+      await jest.advanceTimersByTimeAsync(1);
+      await rejection;
+
+      expect(cancellation).toHaveBeenCalledTimes(1);
+      expect(observedSignals[0].aborted).toBe(true);
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('clears the wall-clock deadline timer after an early proof success', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-16T12:00:00.000Z'));
+    try {
+      let signal: AbortSignal | undefined;
+
+      await expect(
+        loadSandreMdmProofWithRetry(
+          async (budget) => {
+            signal = budget.signal;
+            return 'complete-proof';
+          },
+          jest.fn(),
+          { timeoutMs: 100, now: () => Date.now() },
+        ),
+      ).resolves.toBe('complete-proof');
+
+      expect(jest.getTimerCount()).toBe(0);
+      await jest.advanceTimersByTimeAsync(100);
+      expect(signal?.aborted).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('fails before starting work when the monotonic proof deadline is spent', async () => {
+    const clockReadings = [5_000, 5_010];
+    const loadProof = jest.fn(async () => 'unreachable');
+    const waitForRetry = jest.fn().mockResolvedValue(undefined);
+    const proof = loadSandreMdmProofWithRetry(loadProof, waitForRetry, {
+      timeoutMs: 10,
+      now: () => clockReadings.shift() ?? 5_010,
+    });
+
+    await expect(proof).rejects.toBeInstanceOf(
+      SandreMdmProofDeadlineExceededError,
+    );
+    expect(loadProof).not.toHaveBeenCalled();
+    expect(waitForRetry).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto';
+import { performance } from 'perf_hooks';
 import { load } from 'cheerio';
 import { fingerprint } from './sandre-zone-reconciliation';
 import {
@@ -12,6 +13,128 @@ export const SANDRE_MDM_MAX_ZONE_RECORD_BYTES = 2 * 1024 * 1024;
 export const SANDRE_MDM_NOMENCLATURE_NODE_BASE_URL =
   'https://mdm.sandre.eaufrance.fr/node';
 export const SANDRE_MDM_MAX_NOMENCLATURE_BYTES = 512 * 1024;
+export const SANDRE_MDM_PROOF_ATTEMPTS = 5;
+export const SANDRE_MDM_PROOF_TIMEOUT_MS = 3 * 60 * 1000;
+
+export class SandreMdmTransientError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'SandreMdmTransientError';
+    this.cause = cause;
+  }
+}
+
+export class SandreMdmProofDeadlineExceededError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message = 'Sandre MDM proof deadline exceeded', cause?: unknown) {
+    super(message);
+    this.name = 'SandreMdmProofDeadlineExceededError';
+    this.cause = cause;
+  }
+}
+
+export interface SandreMdmProofBudget {
+  readonly expiresAt: number;
+  readonly signal: AbortSignal;
+  remainingMs(): number;
+  assertRemaining(context?: string, cause?: unknown): number;
+}
+
+export interface SandreMdmProofRetryOptions {
+  attempts?: number;
+  timeoutMs?: number;
+  now?: () => number;
+}
+
+export async function loadSandreMdmProofWithRetry<T>(
+  loadProof: (budget: SandreMdmProofBudget) => Promise<T>,
+  waitForRetry: (
+    attempt: number,
+    budget: SandreMdmProofBudget,
+  ) => Promise<void>,
+  options: SandreMdmProofRetryOptions = {},
+): Promise<T> {
+  const attempts = options.attempts ?? SANDRE_MDM_PROOF_ATTEMPTS;
+  const timeoutMs = options.timeoutMs ?? SANDRE_MDM_PROOF_TIMEOUT_MS;
+  const now = options.now ?? (() => performance.now());
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error('Invalid Sandre MDM proof retry budget');
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('Invalid Sandre MDM proof deadline');
+  }
+  const startedAt = now();
+  if (!Number.isFinite(startedAt)) {
+    throw new Error('Invalid Sandre MDM monotonic clock');
+  }
+  const expiresAt = startedAt + timeoutMs;
+  if (!Number.isFinite(expiresAt)) {
+    throw new Error('Invalid Sandre MDM proof deadline');
+  }
+  const deadlineController = new AbortController();
+  const remainingMs = (): number => {
+    const observedAt = now();
+    if (!Number.isFinite(observedAt)) {
+      throw new Error('Invalid Sandre MDM monotonic clock');
+    }
+    return Math.max(0, Math.ceil(expiresAt - observedAt));
+  };
+  const budget: SandreMdmProofBudget = {
+    expiresAt,
+    signal: deadlineController.signal,
+    remainingMs,
+    assertRemaining: (context = 'before the next operation', cause) => {
+      if (deadlineController.signal.aborted) {
+        throw deadlineController.signal.reason;
+      }
+      const remaining = remainingMs();
+      if (remaining <= 0) {
+        throw new SandreMdmProofDeadlineExceededError(
+          `Sandre MDM proof deadline exceeded ${context}`,
+          cause,
+        );
+      }
+      return remaining;
+    },
+  };
+  let rejectAtDeadline!: (error: SandreMdmProofDeadlineExceededError) => void;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectAtDeadline = reject;
+  });
+  const deadlineTimer = setTimeout(() => {
+    const error = new SandreMdmProofDeadlineExceededError();
+    deadlineController.abort(error);
+    rejectAtDeadline(error);
+  }, budget.assertRemaining('before arming the proof deadline'));
+  try {
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      budget.assertRemaining(`before attempt ${attempt}`);
+      try {
+        return await Promise.race([loadProof(budget), deadline]);
+      } catch (error) {
+        if (!(error instanceof SandreMdmTransientError)) {
+          throw error;
+        }
+        budget.assertRemaining(`after attempt ${attempt}`, error);
+        if (attempt === attempts) {
+          throw Object.assign(
+            new Error(
+              `Sandre MDM proof retry budget exhausted after ${attempts} attempts`,
+            ),
+            { cause: error },
+          );
+        }
+        await Promise.race([waitForRetry(attempt, budget), deadline]);
+      }
+    }
+    throw new Error('Sandre MDM proof retry budget exhausted');
+  } finally {
+    clearTimeout(deadlineTimer);
+  }
+}
 
 export interface SandreMdmTransportResponse {
   status: number;

--- a/apps/backend-admin/src/zone_alerte/zone_alerte.service.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/zone_alerte.service.spec.ts
@@ -7,6 +7,13 @@ import { of } from 'rxjs';
 import { getMetadataArgsStorage } from 'typeorm';
 import * as approvedReferences from './sandre-zone-sync-approved-references';
 import * as syncApprovals from './sandre-zone-sync-approvals';
+import {
+  fetchSandreMdmZoneRecordEvidence,
+  SANDRE_MDM_PROOF_TIMEOUT_MS,
+  SandreMdmProofBudget,
+  SandreMdmProofDeadlineExceededError,
+  SandreMdmTransientError,
+} from './sandre-mdm-evidence';
 import { fingerprint } from './sandre-zone-reconciliation';
 import { createSandreZoneSnapshot } from './sandre-zone-sync';
 import { ZoneAlerteService } from './zone_alerte.service';
@@ -14,6 +21,28 @@ import { ZoneAlerteService } from './zone_alerte.service';
 describe('ZoneAlerteService Sandre synchronization', () => {
   const department = { id: 65, code: '65' };
   const basin = { id: 7, code: 7 };
+  const mdmBudget = (remainingMs = 30_000): SandreMdmProofBudget => ({
+    expiresAt: remainingMs,
+    signal: new AbortController().signal,
+    remainingMs: jest.fn(() => remainingMs),
+    assertRemaining: jest.fn(() => remainingMs),
+  });
+  const mdmApproval = () => ({
+    approvalId: 'test-mdm-proof',
+    mdmRecords: ['355', '3947', '3948'].map((codeSandre) => ({
+      codeSandre,
+      projectionSha256: '0'.repeat(64),
+      requiredEvolution: null,
+    })),
+    mdmNomenclature: {
+      nid: '282836',
+      nomenclatureCode: '590',
+      title: 'Creation',
+      code: '7',
+      mnemonic: 'Creation',
+      projectionSha256: '0'.repeat(64),
+    },
+  });
 
   const rawFeature = (overrides: Record<string, any> = {}) => ({
     type: 'Feature',
@@ -496,6 +525,269 @@ describe('ZoneAlerteService Sandre synchronization', () => {
       'Expected exactly one official Sandre genealogy resource',
     );
     expect(harness.httpService.get).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([429, 500, 502, 503, 504])(
+    'classifies exhausted MDM HTTP %s retries as a transient proof failure',
+    async (status) => {
+      const harness = createHarness({
+        httpResponses: [{ status }, { status }, { status }],
+      });
+      const waitForRetry = jest
+        .spyOn(harness.service as any, 'waitForSandreMdmRequestRetry')
+        .mockResolvedValue(undefined);
+      const budget = mdmBudget(1_234);
+      const controller = new AbortController();
+
+      await expect(
+        (harness.service as any).fetchSandreMdmTransport(
+          'https://mdm.sandre.test/id/355/json',
+          'application/json',
+          2 * 1024 * 1024,
+          budget,
+          controller.signal,
+        ),
+      ).rejects.toBeInstanceOf(SandreMdmTransientError);
+      expect(harness.httpService.get).toHaveBeenCalledTimes(3);
+      expect(waitForRetry.mock.calls.map(([attempt]) => attempt)).toEqual([
+        1, 2,
+      ]);
+      expect(harness.httpService.get).toHaveBeenNthCalledWith(
+        1,
+        'https://mdm.sandre.test/id/355/json',
+        expect.objectContaining({ timeout: 1_234, signal: controller.signal }),
+      );
+    },
+  );
+
+  it.each([501, 505])(
+    'returns MDM HTTP %s to strict validation without retrying',
+    async (status) => {
+      const harness = createHarness({ httpResponses: [{ status }] });
+      const waitForRetry = jest.spyOn(
+        harness.service as any,
+        'waitForSandreMdmRequestRetry',
+      );
+      const controller = new AbortController();
+
+      await expect(
+        fetchSandreMdmZoneRecordEvidence(
+          {
+            codeSandre: '355',
+            projectionSha256: '0'.repeat(64),
+            requiredEvolution: null,
+          },
+          (url) =>
+            (harness.service as any).fetchSandreMdmTransport(
+              url,
+              'application/json',
+              2 * 1024 * 1024,
+              mdmBudget(),
+              controller.signal,
+            ),
+        ),
+      ).rejects.toThrow('Invalid Sandre MDM response for zone 355');
+      expect(harness.httpService.get).toHaveBeenCalledTimes(1);
+      expect(waitForRetry).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects a response that completes after the MDM proof deadline', async () => {
+    const harness = createHarness({ httpResponses: [{ status: 200 }] });
+    const budget = mdmBudget(1_234);
+    (budget.assertRemaining as jest.Mock)
+      .mockReturnValueOnce(1_234)
+      .mockImplementationOnce(() => {
+        throw new SandreMdmProofDeadlineExceededError();
+      });
+
+    await expect(
+      (harness.service as any).fetchSandreMdmTransport(
+        'https://mdm.sandre.test/id/355/json',
+        'application/json',
+        2 * 1024 * 1024,
+        budget,
+        new AbortController().signal,
+      ),
+    ).rejects.toBeInstanceOf(SandreMdmProofDeadlineExceededError);
+    expect(harness.httpService.get).toHaveBeenCalledTimes(1);
+    expect(harness.httpService.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ timeout: 1_234 }),
+    );
+  });
+
+  it('fails closed when the required MDM retry backoff exceeds the deadline', async () => {
+    const harness = createHarness({ httpResponses: [{ status: 503 }] });
+
+    await expect(
+      (harness.service as any).fetchSandreMdmTransport(
+        'https://mdm.sandre.test/id/355/json',
+        'application/json',
+        2 * 1024 * 1024,
+        mdmBudget(250),
+        new AbortController().signal,
+      ),
+    ).rejects.toBeInstanceOf(SandreMdmProofDeadlineExceededError);
+    expect(harness.httpService.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels an MDM request backoff when its proof attempt is aborted', async () => {
+    jest.useFakeTimers();
+    try {
+      const harness = createHarness();
+      const controller = new AbortController();
+      const cancellation = new Error('proof failed elsewhere');
+      const waiting = (harness.service as any).waitForSandreMdmRequestRetry(
+        1,
+        mdmBudget(),
+        controller.signal,
+      );
+      const rejection = expect(waiting).rejects.toBe(cancellation);
+
+      expect(jest.getTimerCount()).toBe(1);
+      controller.abort(cancellation);
+      await rejection;
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('aborts all non-completing MDM reads at one wall-clock proof deadline', async () => {
+    jest.useFakeTimers();
+    try {
+      const harness = createHarness();
+      const cancelledUrls: string[] = [];
+      const transport = jest
+        .spyOn(harness.service as any, 'fetchSandreMdmTransport')
+        .mockImplementation(async (url: string, ...args: any[]) => {
+          const signal = args.at(-1) as AbortSignal;
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => {
+                cancelledUrls.push(url);
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          });
+        });
+      const proof = (harness.service as any).fetchApprovedSandreMdmEvidence(
+        mdmApproval(),
+      );
+      const rejection = expect(proof).rejects.toBeInstanceOf(
+        SandreMdmProofDeadlineExceededError,
+      );
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(transport).toHaveBeenCalledTimes(4);
+      expect(jest.getTimerCount()).toBe(1);
+
+      await jest.advanceTimersByTimeAsync(SANDRE_MDM_PROOF_TIMEOUT_MS / 2);
+      expect(cancelledUrls).toHaveLength(0);
+      expect(jest.getTimerCount()).toBe(1);
+      await jest.advanceTimersByTimeAsync(SANDRE_MDM_PROOF_TIMEOUT_MS / 2);
+      await rejection;
+
+      expect(cancelledUrls).toHaveLength(4);
+      expect(jest.getTimerCount()).toBe(0);
+      expect(harness.queryRunner.startTransaction).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not retry when a transient result wins before sibling validation drift', async () => {
+    const harness = createHarness();
+    const transient = new SandreMdmTransientError('HTTP 500 for 355');
+    let rejectTransient!: (reason: unknown) => void;
+    let resolveValidation!: (response: any) => void;
+    let validationUrl = '';
+    const transport = jest
+      .spyOn(harness.service as any, 'fetchSandreMdmTransport')
+      .mockImplementation(async (url: string, ...args: any[]) => {
+        if (url.endsWith('/355/json')) {
+          return new Promise((_resolve, reject) => {
+            rejectTransient = reject;
+          });
+        }
+        if (url.endsWith('/3947/json')) {
+          validationUrl = url;
+          return new Promise((resolve) => {
+            resolveValidation = resolve;
+          });
+        }
+        const signal = args.at(-1) as AbortSignal;
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        });
+      });
+    const waitForProofRetry = jest.spyOn(
+      harness.service as any,
+      'waitForSandreMdmProofRetry',
+    );
+    const proof = (harness.service as any).fetchApprovedSandreMdmEvidence(
+      mdmApproval(),
+    );
+    const rejection = expect(proof).rejects.toThrow(
+      'Incomplete Sandre MDM zone record',
+    );
+
+    expect(transport).toHaveBeenCalledTimes(4);
+    rejectTransient(transient);
+    resolveValidation({
+      status: 200,
+      contentType: 'application/json',
+      finalUrl: validationUrl,
+      body: '{}',
+    });
+    await rejection;
+
+    expect(waitForProofRetry).not.toHaveBeenCalled();
+    expect(transport).toHaveBeenCalledTimes(4);
+  });
+
+  it('loads one MDM proof in parallel and cancels siblings on validation drift', async () => {
+    const harness = createHarness();
+    const cancelledUrls: string[] = [];
+    const transport = jest
+      .spyOn(harness.service as any, 'fetchSandreMdmTransport')
+      .mockImplementation(async (url: string, ...args: any[]) => {
+        const signal = args.at(-1) as AbortSignal;
+        if (url.endsWith('/355/json')) {
+          return {
+            status: 302,
+            contentType: 'application/json',
+            finalUrl: url,
+            body: '{}',
+          };
+        }
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              cancelledUrls.push(url);
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        });
+      });
+    const approval = mdmApproval();
+
+    await expect(
+      (harness.service as any).fetchApprovedSandreMdmEvidenceAttempt(
+        approval,
+        mdmBudget(),
+      ),
+    ).rejects.toThrow('Invalid Sandre MDM response for zone 355');
+    expect(transport).toHaveBeenCalledTimes(4);
+    expect(cancelledUrls).toHaveLength(3);
+    expect(harness.queryRunner.startTransaction).not.toHaveBeenCalled();
   });
 
   it('rejects an incomplete paginated snapshot before opening a transaction', async () => {

--- a/apps/backend-admin/src/zone_alerte/zone_alerte.service.ts
+++ b/apps/backend-admin/src/zone_alerte/zone_alerte.service.ts
@@ -63,8 +63,12 @@ import {
 import {
   fetchSandreMdmNomenclatureEvidence,
   fetchSandreMdmZoneRecordEvidence,
+  loadSandreMdmProofWithRetry,
   SandreMdmNomenclatureEvidence,
+  SandreMdmProofBudget,
+  SandreMdmProofDeadlineExceededError,
   SandreMdmTransportResponse,
+  SandreMdmTransientError,
   SandreMdmZoneRecordEvidence,
 } from './sandre-mdm-evidence';
 import {
@@ -88,6 +92,11 @@ const SANDRE_HTTP_TIMEOUT_MS = 30 * 1000;
 const SANDRE_GENEALOGY_CACHE_MS = 10 * 60 * 1000;
 const SANDRE_GENEALOGY_METADATA_MAX_BYTES = 1024 * 1024;
 const SANDRE_GENEALOGY_CSV_MAX_BYTES = 20 * 1024 * 1024;
+const SANDRE_MDM_REQUEST_ATTEMPTS = 3;
+const SANDRE_MDM_REQUEST_TIMEOUT_MS = 60_000;
+const SANDRE_MDM_REQUEST_RETRY_BASE_MS = 250;
+const SANDRE_MDM_PROOF_RETRY_BASE_MS = 2_000;
+const SANDRE_MDM_TRANSIENT_HTTP_STATUSES = new Set([429, 500, 502, 503, 504]);
 const SANDRE_VALID_STATUS = 'Validé';
 const SANDRE_ZONE_SELECT = {
   id: true,
@@ -3063,44 +3072,102 @@ export class ZoneAlerteService {
   private async fetchApprovedSandreMdmEvidence(
     approval: SandreApprovedSyncSnapshot,
   ): Promise<SandreApprovedMdmEvidence> {
-    const zoneRecords = await Promise.all(
-      approval.mdmRecords.map((expectation) =>
-        fetchSandreMdmZoneRecordEvidence(expectation, (url) =>
-          this.fetchSandreMdmTransport(
-            url,
-            'application/json',
-            2 * 1024 * 1024,
-          ),
+    return loadSandreMdmProofWithRetry(
+      (budget) => this.fetchApprovedSandreMdmEvidenceAttempt(approval, budget),
+      (attempt, budget) => this.waitForSandreMdmProofRetry(attempt, budget),
+    );
+  }
+
+  private async fetchApprovedSandreMdmEvidenceAttempt(
+    approval: SandreApprovedSyncSnapshot,
+    budget: SandreMdmProofBudget,
+  ): Promise<SandreApprovedMdmEvidence> {
+    budget.assertRemaining('before loading the approved resources');
+    const controller = new AbortController();
+    const attemptCancellation = new Error('Sandre MDM proof attempt cancelled');
+    const cancelAttemptAtProofDeadline = () => {
+      controller.abort(this.sandreMdmCancellationError(budget.signal));
+    };
+    if (budget.signal.aborted) {
+      cancelAttemptAtProofDeadline();
+    } else {
+      budget.signal.addEventListener('abort', cancelAttemptAtProofDeadline, {
+        once: true,
+      });
+    }
+    const zoneRecordPromises = approval.mdmRecords.map((expectation) =>
+      fetchSandreMdmZoneRecordEvidence(expectation, (url) =>
+        this.fetchSandreMdmTransport(
+          url,
+          'application/json',
+          2 * 1024 * 1024,
+          budget,
+          controller.signal,
         ),
       ),
     );
-    const nomenclature = approval.mdmNomenclature
-      ? await fetchSandreMdmNomenclatureEvidence(
-          approval.mdmNomenclature,
-          (url) =>
-            this.fetchSandreMdmTransport(
-              url,
-              'text/html,application/xhtml+xml;q=0.9',
-              512 * 1024,
-            ),
+    const nomenclaturePromise = approval.mdmNomenclature
+      ? fetchSandreMdmNomenclatureEvidence(approval.mdmNomenclature, (url) =>
+          this.fetchSandreMdmTransport(
+            url,
+            'text/html,application/xhtml+xml;q=0.9',
+            512 * 1024,
+            budget,
+            controller.signal,
+          ),
         )
-      : null;
-    return { approvalId: approval.approvalId, zoneRecords, nomenclature };
+      : Promise.resolve(null);
+    try {
+      const [zoneRecords, nomenclature] = await Promise.all([
+        Promise.all(zoneRecordPromises),
+        nomenclaturePromise,
+      ]);
+      budget.assertRemaining('after validating the approved resources');
+      return { approvalId: approval.approvalId, zoneRecords, nomenclature };
+    } catch (error) {
+      controller.abort(attemptCancellation);
+      const settledResources = await Promise.allSettled([
+        ...zoneRecordPromises,
+        nomenclaturePromise,
+      ]);
+      const nonRetryableFailure = settledResources.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected' &&
+          result.reason !== attemptCancellation &&
+          !(result.reason instanceof SandreMdmTransientError),
+      );
+      if (nonRetryableFailure) {
+        throw nonRetryableFailure.reason;
+      }
+      throw error;
+    } finally {
+      budget.signal.removeEventListener('abort', cancelAttemptAtProofDeadline);
+    }
   }
 
   private async fetchSandreMdmTransport(
     url: string,
     accept: string,
     maximumBytes: number,
+    budget: SandreMdmProofBudget,
+    signal: AbortSignal,
   ): Promise<SandreMdmTransportResponse> {
-    const attempts = 3;
-    for (let attempt = 1; attempt <= attempts; attempt++) {
+    for (let attempt = 1; attempt <= SANDRE_MDM_REQUEST_ATTEMPTS; attempt++) {
+      if (signal.aborted) {
+        throw this.sandreMdmCancellationError(signal);
+      }
+      const timeout = Math.min(
+        SANDRE_MDM_REQUEST_TIMEOUT_MS,
+        budget.assertRemaining(`before requesting ${url}`),
+      );
+      let response;
       try {
-        const response = await firstValueFrom(
+        response = await firstValueFrom(
           this.httpService.get(url, {
             headers: { accept, 'accept-language': 'fr' },
             responseType: 'text',
-            timeout: 60_000,
+            timeout,
+            signal,
             maxRedirects: 0,
             maxContentLength: maximumBytes,
             maxBodyLength: maximumBytes,
@@ -3108,51 +3175,117 @@ export class ZoneAlerteService {
             validateStatus: () => true,
           }),
         );
-        if (
-          attempt < attempts &&
-          (response.status === 429 || response.status >= 500)
-        ) {
-          await this.waitForSandreMdmRetry(attempt);
-          continue;
-        }
-        return {
-          status: response.status,
-          contentType:
-            typeof response.headers?.['content-type'] === 'string'
-              ? response.headers['content-type']
-              : null,
-          finalUrl:
-            response.request?.res?.responseUrl ??
-            response.request?.responseURL ??
-            url,
-          body: typeof response.data === 'string' ? response.data : '',
-        };
       } catch (error) {
+        if (signal.aborted) {
+          throw this.sandreMdmCancellationError(signal);
+        }
+        budget.assertRemaining(`while requesting ${url}`, error);
         const code =
           error && typeof error === 'object' && 'code' in error
             ? String(error.code)
             : '';
-        if (
-          attempt === attempts ||
-          ![
-            'ECONNABORTED',
-            'ECONNRESET',
-            'ECONNREFUSED',
-            'EAI_AGAIN',
-            'ENETUNREACH',
-            'ETIMEDOUT',
-          ].includes(code)
-        ) {
+        const transient = [
+          'ECONNABORTED',
+          'ECONNRESET',
+          'ECONNREFUSED',
+          'EAI_AGAIN',
+          'ENETUNREACH',
+          'ETIMEDOUT',
+        ].includes(code);
+        if (!transient) {
           throw error;
         }
-        await this.waitForSandreMdmRetry(attempt);
+        if (attempt === SANDRE_MDM_REQUEST_ATTEMPTS) {
+          throw new SandreMdmTransientError(
+            `Transient Sandre MDM transport failure for ${url}`,
+            error,
+          );
+        }
+        await this.waitForSandreMdmRequestRetry(attempt, budget, signal);
+        continue;
       }
+      budget.assertRemaining(`after requesting ${url}`);
+      if (SANDRE_MDM_TRANSIENT_HTTP_STATUSES.has(response.status)) {
+        if (attempt === SANDRE_MDM_REQUEST_ATTEMPTS) {
+          throw new SandreMdmTransientError(
+            `Transient Sandre MDM HTTP ${response.status} for ${url}`,
+          );
+        }
+        await this.waitForSandreMdmRequestRetry(attempt, budget, signal);
+        continue;
+      }
+      return {
+        status: response.status,
+        contentType:
+          typeof response.headers?.['content-type'] === 'string'
+            ? response.headers['content-type']
+            : null,
+        finalUrl:
+          response.request?.res?.responseUrl ??
+          response.request?.responseURL ??
+          url,
+        body: typeof response.data === 'string' ? response.data : '',
+      };
     }
-    throw new Error('Sandre MDM retry budget exhausted');
+    throw new Error('Sandre MDM request retry budget exhausted');
   }
 
-  private async waitForSandreMdmRetry(attempt: number): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, attempt * 100));
+  private async waitForSandreMdmRequestRetry(
+    attempt: number,
+    budget: SandreMdmProofBudget,
+    signal: AbortSignal,
+  ): Promise<void> {
+    await this.waitForSandreMdmDelay(
+      SANDRE_MDM_REQUEST_RETRY_BASE_MS * 2 ** (attempt - 1),
+      budget,
+      signal,
+    );
+  }
+
+  private async waitForSandreMdmProofRetry(
+    attempt: number,
+    budget: SandreMdmProofBudget,
+  ): Promise<void> {
+    await this.waitForSandreMdmDelay(
+      SANDRE_MDM_PROOF_RETRY_BASE_MS * 2 ** (attempt - 1),
+      budget,
+      budget.signal,
+    );
+  }
+
+  private async waitForSandreMdmDelay(
+    delayMs: number,
+    budget: SandreMdmProofBudget,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (signal?.aborted) {
+      throw this.sandreMdmCancellationError(signal);
+    }
+    const remainingMs = budget.assertRemaining('before retry backoff');
+    if (delayMs >= remainingMs) {
+      throw new SandreMdmProofDeadlineExceededError(
+        'Sandre MDM proof deadline leaves no room for the required backoff',
+      );
+    }
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', onAbort);
+        reject(this.sandreMdmCancellationError(signal!));
+      };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, delayMs);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+    budget.assertRemaining('after retry backoff');
+  }
+
+  private sandreMdmCancellationError(signal: AbortSignal): Error {
+    return signal.reason instanceof Error
+      ? signal.reason
+      : new Error('Sandre MDM proof attempt cancelled');
   }
 
   private async lockOperationalParentsForSandreSources(


### PR DESCRIPTION
## Summary
- retry the complete SANDRE MDM proof only for bounded transient failures
- cap the whole proof at a 180-second monotonic wall-clock deadline
- cancel and drain concurrent MDM requests while preserving strict evidence validation

## Validation
- backend-admin build
- targeted Jest: 109 tests
- full backend-admin Jest: 1057 passed, 60 skipped
- targeted ESLint
- git diff --check

## Rollout
Production remains frozen. A fresh SANDRE audit and safe pass will only run after this change is merged, validated in preproduction, and deployed to the admin backend.