### PR TITLE
Retain validated SANDRE MDM proof evidence

### DIFF
--- a/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.spec.ts
@@ -266,6 +266,48 @@ describe('Sandre MDM split evidence', () => {
     expect(waitForRetry.mock.calls.map(([attempt]) => attempt)).toEqual([1, 2]);
   });
 
+  it('keeps retrying transient proof beyond five attempts until the active deadline', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-16T12:00:00.000Z'));
+    try {
+      const transient = new SandreMdmTransientError('HTTP 500');
+      const loadProof = jest.fn().mockRejectedValue(transient);
+      const waitForRetry = jest.fn(
+        (_attempt: number, budget: { signal: AbortSignal }) =>
+          new Promise<void>((resolve, reject) => {
+            const onAbort = () => {
+              clearTimeout(timer);
+              reject(budget.signal.reason);
+            };
+            const timer = setTimeout(() => {
+              budget.signal.removeEventListener('abort', onAbort);
+              resolve();
+            }, 10);
+            budget.signal.addEventListener('abort', onAbort, { once: true });
+          }),
+      );
+      const proof = loadSandreMdmProofWithRetry(loadProof, waitForRetry, {
+        timeoutMs: 60,
+        now: () => Date.now(),
+      });
+      const rejection = expect(proof).rejects.toBeInstanceOf(
+        SandreMdmProofDeadlineExceededError,
+      );
+
+      await jest.advanceTimersByTimeAsync(59);
+      expect(loadProof).toHaveBeenCalledTimes(6);
+      expect(waitForRetry.mock.calls.map(([attempt]) => attempt)).toEqual([
+        1, 2, 3, 4, 5, 6,
+      ]);
+      await jest.advanceTimersByTimeAsync(1);
+      await rejection;
+
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('does not retry validation drift', async () => {
     const validationError = new Error(
       'Sandre MDM projection changed for zone 3947',

--- a/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.ts
+++ b/apps/backend-admin/src/zone_alerte/sandre-mdm-evidence.ts
@@ -13,7 +13,6 @@ export const SANDRE_MDM_MAX_ZONE_RECORD_BYTES = 2 * 1024 * 1024;
 export const SANDRE_MDM_NOMENCLATURE_NODE_BASE_URL =
   'https://mdm.sandre.eaufrance.fr/node';
 export const SANDRE_MDM_MAX_NOMENCLATURE_BYTES = 512 * 1024;
-export const SANDRE_MDM_PROOF_ATTEMPTS = 5;
 export const SANDRE_MDM_PROOF_TIMEOUT_MS = 3 * 60 * 1000;
 
 export class SandreMdmTransientError extends Error {
@@ -57,10 +56,10 @@ export async function loadSandreMdmProofWithRetry<T>(
   ) => Promise<void>,
   options: SandreMdmProofRetryOptions = {},
 ): Promise<T> {
-  const attempts = options.attempts ?? SANDRE_MDM_PROOF_ATTEMPTS;
+  const attempts = options.attempts;
   const timeoutMs = options.timeoutMs ?? SANDRE_MDM_PROOF_TIMEOUT_MS;
   const now = options.now ?? (() => performance.now());
-  if (!Number.isInteger(attempts) || attempts < 1) {
+  if (attempts !== undefined && (!Number.isInteger(attempts) || attempts < 1)) {
     throw new Error('Invalid Sandre MDM proof retry budget');
   }
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
@@ -110,7 +109,7 @@ export async function loadSandreMdmProofWithRetry<T>(
     rejectAtDeadline(error);
   }, budget.assertRemaining('before arming the proof deadline'));
   try {
-    for (let attempt = 1; attempt <= attempts; attempt++) {
+    for (let attempt = 1; ; attempt++) {
       budget.assertRemaining(`before attempt ${attempt}`);
       try {
         return await Promise.race([loadProof(budget), deadline]);
@@ -119,7 +118,7 @@ export async function loadSandreMdmProofWithRetry<T>(
           throw error;
         }
         budget.assertRemaining(`after attempt ${attempt}`, error);
-        if (attempt === attempts) {
+        if (attempts !== undefined && attempt === attempts) {
           throw Object.assign(
             new Error(
               `Sandre MDM proof retry budget exhausted after ${attempts} attempts`,
@@ -130,7 +129,6 @@ export async function loadSandreMdmProofWithRetry<T>(
         await Promise.race([waitForRetry(attempt, budget), deadline]);
       }
     }
-    throw new Error('Sandre MDM proof retry budget exhausted');
   } finally {
     clearTimeout(deadlineTimer);
   }

--- a/apps/backend-admin/src/zone_alerte/zone_alerte.service.spec.ts
+++ b/apps/backend-admin/src/zone_alerte/zone_alerte.service.spec.ts
@@ -43,6 +43,96 @@ describe('ZoneAlerteService Sandre synchronization', () => {
       projectionSha256: '0'.repeat(64),
     },
   });
+  const mdmRecordProjection = (codeSandre: string) => ({
+    nid: `nid-${codeSandre}`,
+    title: `[${codeSandre}] Test zone`,
+    changed: '1',
+    code: [{ value: codeSandre }],
+    status: [{ nid: '6513' }],
+    evolutionTypes: [],
+    evolutionDates: [],
+    evolutionComments: [],
+    undergoes: [],
+    alternate: [],
+    dateCreated: [],
+    dateUpdated: [],
+  });
+  const mdmRecordBody = (projection: ReturnType<typeof mdmRecordProjection>) =>
+    JSON.stringify({
+      nid: projection.nid,
+      title: projection.title,
+      changed: projection.changed,
+      field_zas_cdzas: projection.code,
+      field_zas_statutzas: projection.status,
+      field_zas_typeevolution: projection.evolutionTypes,
+      field_zas_dateevolution: projection.evolutionDates,
+      field_zas_comevolution: projection.evolutionComments,
+      field_zas_subitevolution: projection.undergoes,
+      field_zas_codealternatif: projection.alternate,
+      field_zas_datecreazas: projection.dateCreated,
+      field_zas_datemajzas: projection.dateUpdated,
+    });
+  const mdmNomenclatureProjection = {
+    nid: '282836',
+    nomenclatureCode: '590',
+    title: 'Creation',
+    code: '7',
+    mnemonic: 'Creation',
+  };
+  const mdmNomenclatureBody = `
+    <article id="node-282836" class="node-nsa_590">
+      <h2>Creation</h2>
+      <div class="field">
+        <div class="field-label">CdElement:</div>
+        <div class="field-item">7</div>
+      </div>
+      <div class="field">
+        <div class="field-label">MnElement:</div>
+        <div class="field-item">Creation</div>
+      </div>
+    </article>
+  `;
+  const exactMdmApproval = () => ({
+    approvalId: 'test-exact-mdm-proof',
+    mdmRecords: ['355', '3947', '3948'].map((codeSandre) => ({
+      codeSandre,
+      projectionSha256: fingerprint(mdmRecordProjection(codeSandre)),
+      requiredEvolution: null,
+    })),
+    mdmNomenclature: {
+      nid: mdmNomenclatureProjection.nid,
+      nomenclatureCode: mdmNomenclatureProjection.nomenclatureCode,
+      title: mdmNomenclatureProjection.title,
+      code: mdmNomenclatureProjection.code,
+      mnemonic: mdmNomenclatureProjection.mnemonic,
+      projectionSha256: fingerprint(mdmNomenclatureProjection),
+    },
+  });
+  const exactMdmResponse = (url: string, driftCode?: string) => {
+    if (url.endsWith('/node/282836')) {
+      return {
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        finalUrl: url,
+        body: mdmNomenclatureBody,
+      };
+    }
+    const codeSandre = url.match(/\/([^/]+)\/json$/)?.[1];
+    if (!codeSandre) {
+      throw new Error(`Unexpected MDM test URL ${url}`);
+    }
+    const projection = mdmRecordProjection(codeSandre);
+    return {
+      status: 200,
+      contentType: 'application/json',
+      finalUrl: url,
+      body: mdmRecordBody(
+        codeSandre === driftCode
+          ? { ...projection, title: `${projection.title} drift` }
+          : projection,
+      ),
+    };
+  };
 
   const rawFeature = (overrides: Record<string, any> = {}) => ({
     type: 'Feature',
@@ -654,6 +744,279 @@ describe('ZoneAlerteService Sandre synchronization', () => {
     }
   });
 
+  it('caps proof retry backoff and fits its last wait inside the remaining budget', async () => {
+    jest.useFakeTimers();
+    try {
+      const harness = createHarness();
+      let cappedSettled = false;
+      const cappedWait = (harness.service as any).waitForSandreMdmProofRetry(
+        100,
+        mdmBudget(15_000),
+      );
+      cappedWait.then(() => {
+        cappedSettled = true;
+      });
+
+      await jest.advanceTimersByTimeAsync(9_999);
+      expect(cappedSettled).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      await cappedWait;
+
+      let finalSettled = false;
+      const finalWait = (harness.service as any).waitForSandreMdmProofRetry(
+        100,
+        mdmBudget(4_000),
+      );
+      finalWait.then(() => {
+        finalSettled = true;
+      });
+      await jest.advanceTimersByTimeAsync(3_998);
+      expect(finalSettled).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      await finalWait;
+
+      expect(finalSettled).toBe(true);
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('drains slower successful siblings after a transient failure and retries only the missing resource', async () => {
+    const harness = createHarness();
+    const pendingResponses = new Map<
+      string,
+      {
+        url: string;
+        resolve: (response: ReturnType<typeof exactMdmResponse>) => void;
+      }
+    >();
+    const callsByResource = new Map<string, number>();
+    const transport = jest
+      .spyOn(harness.service as any, 'fetchSandreMdmTransport')
+      .mockImplementation(async (url: string) => {
+        const resource = url.endsWith('/node/282836')
+          ? '282836'
+          : url.match(/\/([^/]+)\/json$/)?.[1];
+        if (!resource) {
+          throw new Error(`Unexpected MDM test URL ${url}`);
+        }
+        const call = (callsByResource.get(resource) ?? 0) + 1;
+        callsByResource.set(resource, call);
+        if (resource === '355') {
+          if (call === 1) {
+            throw new SandreMdmTransientError('HTTP 500 for 355');
+          }
+          return exactMdmResponse(url);
+        }
+        return new Promise((resolve) => {
+          pendingResponses.set(resource, { url, resolve });
+        });
+      });
+    const waitForProofRetry = jest
+      .spyOn(harness.service as any, 'waitForSandreMdmProofRetry')
+      .mockResolvedValue(undefined);
+    const proof = (harness.service as any).fetchApprovedSandreMdmEvidence(
+      exactMdmApproval(),
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(transport).toHaveBeenCalledTimes(4);
+    expect(waitForProofRetry).not.toHaveBeenCalled();
+
+    for (const resource of ['3947', '3948', '282836']) {
+      const pending = pendingResponses.get(resource);
+      if (!pending) {
+        throw new Error(`Missing pending MDM test response for ${resource}`);
+      }
+      pending.resolve(exactMdmResponse(pending.url));
+    }
+
+    await expect(proof).resolves.toEqual(
+      expect.objectContaining({
+        zoneRecords: [
+          expect.objectContaining({ codeSandre: '355' }),
+          expect.objectContaining({ codeSandre: '3947' }),
+          expect.objectContaining({ codeSandre: '3948' }),
+        ],
+      }),
+    );
+    expect(Object.fromEntries(callsByResource)).toEqual({
+      '355': 2,
+      '3947': 1,
+      '3948': 1,
+      '282836': 1,
+    });
+    expect(waitForProofRetry).toHaveBeenCalledTimes(1);
+    expect(harness.queryRunner.startTransaction).not.toHaveBeenCalled();
+  });
+
+  it('lets the global deadline abort hanging siblings after a transient-first failure', async () => {
+    jest.useFakeTimers();
+    try {
+      const harness = createHarness();
+      const cancelledResources: string[] = [];
+      const transport = jest
+        .spyOn(harness.service as any, 'fetchSandreMdmTransport')
+        .mockImplementation(async (url: string, ...args: any[]) => {
+          const resource = url.endsWith('/node/282836')
+            ? '282836'
+            : url.match(/\/([^/]+)\/json$/)?.[1];
+          if (!resource) {
+            throw new Error(`Unexpected MDM test URL ${url}`);
+          }
+          if (resource === '355') {
+            throw new SandreMdmTransientError('HTTP 500 for 355');
+          }
+          if (resource === '3947') {
+            return exactMdmResponse(url);
+          }
+          const signal = args.at(-1) as AbortSignal;
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => {
+                cancelledResources.push(resource);
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          });
+        });
+      const waitForProofRetry = jest.spyOn(
+        harness.service as any,
+        'waitForSandreMdmProofRetry',
+      );
+      const proof = (harness.service as any).fetchApprovedSandreMdmEvidence(
+        exactMdmApproval(),
+      );
+      const rejection = expect(proof).rejects.toBeInstanceOf(
+        SandreMdmProofDeadlineExceededError,
+      );
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(transport).toHaveBeenCalledTimes(4);
+      expect(cancelledResources).toEqual([]);
+      expect(waitForProofRetry).not.toHaveBeenCalled();
+      await jest.advanceTimersByTimeAsync(SANDRE_MDM_PROOF_TIMEOUT_MS - 1);
+      expect(cancelledResources).toEqual([]);
+      await jest.advanceTimersByTimeAsync(1);
+      await rejection;
+
+      expect(cancelledResources.sort()).toEqual(['282836', '3948']);
+      expect(waitForProofRetry).not.toHaveBeenCalled();
+      expect(jest.getTimerCount()).toBe(0);
+      expect(harness.queryRunner.startTransaction).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('accumulates four strictly validated MDM resources beyond five rotating transient attempts', async () => {
+    const harness = createHarness();
+    const successOnCall = new Map([
+      ['355', 1],
+      ['3947', 2],
+      ['3948', 3],
+      ['282836', 7],
+    ]);
+    const callsByResource = new Map<string, number>();
+    const transport = jest
+      .spyOn(harness.service as any, 'fetchSandreMdmTransport')
+      .mockImplementation(async (url: string) => {
+        const resource = url.endsWith('/node/282836')
+          ? '282836'
+          : url.match(/\/([^/]+)\/json$/)?.[1];
+        if (!resource) {
+          throw new Error(`Unexpected MDM test URL ${url}`);
+        }
+        const call = (callsByResource.get(resource) ?? 0) + 1;
+        callsByResource.set(resource, call);
+        if (call < successOnCall.get(resource)!) {
+          throw new SandreMdmTransientError(`HTTP 500 for ${resource}`);
+        }
+        return exactMdmResponse(url);
+      });
+    const waitForProofRetry = jest
+      .spyOn(harness.service as any, 'waitForSandreMdmProofRetry')
+      .mockResolvedValue(undefined);
+
+    await expect(
+      (harness.service as any).fetchApprovedSandreMdmEvidence(
+        exactMdmApproval(),
+      ),
+    ).resolves.toEqual({
+      approvalId: 'test-exact-mdm-proof',
+      zoneRecords: [
+        expect.objectContaining({ codeSandre: '355' }),
+        expect.objectContaining({ codeSandre: '3947' }),
+        expect.objectContaining({ codeSandre: '3948' }),
+      ],
+      nomenclature: expect.objectContaining({
+        projection: mdmNomenclatureProjection,
+      }),
+    });
+
+    expect(Object.fromEntries(callsByResource)).toEqual({
+      '355': 1,
+      '3947': 2,
+      '3948': 3,
+      '282836': 7,
+    });
+    expect(transport).toHaveBeenCalledTimes(13);
+    expect(waitForProofRetry.mock.calls.map(([attempt]) => attempt)).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
+    expect(harness.queryRunner.startTransaction).not.toHaveBeenCalled();
+  });
+
+  it('keeps validated evidence write-once within a proof and revalidates it on the next proof', async () => {
+    const harness = createHarness();
+    const callsByResource = new Map<string, number>();
+    jest
+      .spyOn(harness.service as any, 'fetchSandreMdmTransport')
+      .mockImplementation(async (url: string) => {
+        const resource = url.endsWith('/node/282836')
+          ? '282836'
+          : url.match(/\/([^/]+)\/json$/)?.[1];
+        if (!resource) {
+          throw new Error(`Unexpected MDM test URL ${url}`);
+        }
+        const call = (callsByResource.get(resource) ?? 0) + 1;
+        callsByResource.set(resource, call);
+        if (resource === '3947' && call === 1) {
+          throw new SandreMdmTransientError('HTTP 500 for 3947');
+        }
+        return exactMdmResponse(
+          url,
+          resource === '355' && call === 2 ? '355' : undefined,
+        );
+      });
+    const waitForProofRetry = jest
+      .spyOn(harness.service as any, 'waitForSandreMdmProofRetry')
+      .mockResolvedValue(undefined);
+    const approval = exactMdmApproval();
+
+    await expect(
+      (harness.service as any).fetchApprovedSandreMdmEvidence(approval),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        zoneRecords: expect.arrayContaining([
+          expect.objectContaining({ codeSandre: '355' }),
+        ]),
+      }),
+    );
+    expect(callsByResource.get('355')).toBe(1);
+
+    await expect(
+      (harness.service as any).fetchApprovedSandreMdmEvidence(approval),
+    ).rejects.toThrow('Sandre MDM projection changed for zone 355');
+    expect(callsByResource.get('355')).toBe(2);
+    expect(waitForProofRetry).toHaveBeenCalledTimes(1);
+    expect(harness.queryRunner.startTransaction).not.toHaveBeenCalled();
+  });
+
   it('aborts all non-completing MDM reads at one wall-clock proof deadline', async () => {
     jest.useFakeTimers();
     try {
@@ -751,7 +1114,7 @@ describe('ZoneAlerteService Sandre synchronization', () => {
     expect(transport).toHaveBeenCalledTimes(4);
   });
 
-  it('loads one MDM proof in parallel and cancels siblings on validation drift', async () => {
+  it('cancels sibling MDM reads when a non-transient validation fails first', async () => {
     const harness = createHarness();
     const cancelledUrls: string[] = [];
     const transport = jest

--- a/apps/backend-admin/src/zone_alerte/zone_alerte.service.ts
+++ b/apps/backend-admin/src/zone_alerte/zone_alerte.service.ts
@@ -96,6 +96,7 @@ const SANDRE_MDM_REQUEST_ATTEMPTS = 3;
 const SANDRE_MDM_REQUEST_TIMEOUT_MS = 60_000;
 const SANDRE_MDM_REQUEST_RETRY_BASE_MS = 250;
 const SANDRE_MDM_PROOF_RETRY_BASE_MS = 2_000;
+const SANDRE_MDM_PROOF_RETRY_MAX_MS = 10_000;
 const SANDRE_MDM_TRANSIENT_HTTP_STATUSES = new Set([429, 500, 502, 503, 504]);
 const SANDRE_VALID_STATUS = 'Validé';
 const SANDRE_ZONE_SELECT = {
@@ -200,6 +201,11 @@ interface SandreApprovedMdmEvidence {
   approvalId: string;
   zoneRecords: SandreMdmZoneRecordEvidence[];
   nomenclature: SandreMdmNomenclatureEvidence | null;
+}
+
+interface SandreApprovedMdmEvidenceAccumulator {
+  zoneRecords: Array<SandreMdmZoneRecordEvidence | undefined>;
+  nomenclature: SandreMdmNomenclatureEvidence | null | undefined;
 }
 
 interface SandreApprovedSourceIdentityEvidence {
@@ -3072,8 +3078,18 @@ export class ZoneAlerteService {
   private async fetchApprovedSandreMdmEvidence(
     approval: SandreApprovedSyncSnapshot,
   ): Promise<SandreApprovedMdmEvidence> {
+    // A proof call validates each resource once; retries only fill missing slots.
+    const accumulatedEvidence: SandreApprovedMdmEvidenceAccumulator = {
+      zoneRecords: approval.mdmRecords.map(() => undefined),
+      nomenclature: approval.mdmNomenclature ? undefined : null,
+    };
     return loadSandreMdmProofWithRetry(
-      (budget) => this.fetchApprovedSandreMdmEvidenceAttempt(approval, budget),
+      (budget) =>
+        this.fetchApprovedSandreMdmEvidenceAttempt(
+          approval,
+          budget,
+          accumulatedEvidence,
+        ),
       (attempt, budget) => this.waitForSandreMdmProofRetry(attempt, budget),
     );
   }
@@ -3081,6 +3097,10 @@ export class ZoneAlerteService {
   private async fetchApprovedSandreMdmEvidenceAttempt(
     approval: SandreApprovedSyncSnapshot,
     budget: SandreMdmProofBudget,
+    accumulatedEvidence: SandreApprovedMdmEvidenceAccumulator = {
+      zoneRecords: approval.mdmRecords.map(() => undefined),
+      nomenclature: approval.mdmNomenclature ? undefined : null,
+    },
   ): Promise<SandreApprovedMdmEvidence> {
     budget.assertRemaining('before loading the approved resources');
     const controller = new AbortController();
@@ -3095,41 +3115,97 @@ export class ZoneAlerteService {
         once: true,
       });
     }
-    const zoneRecordPromises = approval.mdmRecords.map((expectation) =>
-      fetchSandreMdmZoneRecordEvidence(expectation, (url) =>
-        this.fetchSandreMdmTransport(
-          url,
-          'application/json',
-          2 * 1024 * 1024,
-          budget,
-          controller.signal,
-        ),
-      ),
+    const abortSiblingsOnNonRetryableFailure = <T>(
+      resource: Promise<T>,
+    ): Promise<T> =>
+      resource.catch((error) => {
+        if (
+          error !== attemptCancellation &&
+          !(error instanceof SandreMdmTransientError) &&
+          !budget.signal.aborted
+        ) {
+          controller.abort(attemptCancellation);
+        }
+        throw error;
+      });
+    const zoneRecordPromises = approval.mdmRecords.flatMap(
+      (expectation, index) =>
+        accumulatedEvidence.zoneRecords[index] !== undefined
+          ? []
+          : [
+              abortSiblingsOnNonRetryableFailure(
+                fetchSandreMdmZoneRecordEvidence(expectation, (url) =>
+                  this.fetchSandreMdmTransport(
+                    url,
+                    'application/json',
+                    2 * 1024 * 1024,
+                    budget,
+                    controller.signal,
+                  ),
+                ).then((evidence) => {
+                  if (accumulatedEvidence.zoneRecords[index] !== undefined) {
+                    throw new Error(
+                      `Sandre MDM zone ${expectation.codeSandre} was validated more than once`,
+                    );
+                  }
+                  accumulatedEvidence.zoneRecords[index] = evidence;
+                  return evidence;
+                }),
+              ),
+            ],
     );
-    const nomenclaturePromise = approval.mdmNomenclature
-      ? fetchSandreMdmNomenclatureEvidence(approval.mdmNomenclature, (url) =>
-          this.fetchSandreMdmTransport(
-            url,
-            'text/html,application/xhtml+xml;q=0.9',
-            512 * 1024,
-            budget,
-            controller.signal,
-          ),
-        )
-      : Promise.resolve(null);
+    const nomenclaturePromises =
+      approval.mdmNomenclature && accumulatedEvidence.nomenclature === undefined
+        ? [
+            abortSiblingsOnNonRetryableFailure(
+              fetchSandreMdmNomenclatureEvidence(
+                approval.mdmNomenclature,
+                (url) =>
+                  this.fetchSandreMdmTransport(
+                    url,
+                    'text/html,application/xhtml+xml;q=0.9',
+                    512 * 1024,
+                    budget,
+                    controller.signal,
+                  ),
+              ).then((evidence) => {
+                if (accumulatedEvidence.nomenclature !== undefined) {
+                  throw new Error(
+                    'Sandre MDM nomenclature was validated more than once',
+                  );
+                }
+                accumulatedEvidence.nomenclature = evidence;
+                return evidence;
+              }),
+            ),
+          ]
+        : [];
+    const resourcePromises = [...zoneRecordPromises, ...nomenclaturePromises];
     try {
-      const [zoneRecords, nomenclature] = await Promise.all([
-        Promise.all(zoneRecordPromises),
-        nomenclaturePromise,
-      ]);
+      await Promise.all(resourcePromises);
       budget.assertRemaining('after validating the approved resources');
-      return { approvalId: approval.approvalId, zoneRecords, nomenclature };
+      const zoneRecords = accumulatedEvidence.zoneRecords.filter(
+        (record): record is SandreMdmZoneRecordEvidence => record !== undefined,
+      );
+      if (zoneRecords.length !== approval.mdmRecords.length) {
+        throw new Error('Incomplete accumulated Sandre MDM zone evidence');
+      }
+      if (
+        approval.mdmNomenclature &&
+        accumulatedEvidence.nomenclature === undefined
+      ) {
+        throw new Error('Incomplete accumulated Sandre MDM nomenclature');
+      }
+      return {
+        approvalId: approval.approvalId,
+        zoneRecords,
+        nomenclature: accumulatedEvidence.nomenclature ?? null,
+      };
     } catch (error) {
-      controller.abort(attemptCancellation);
-      const settledResources = await Promise.allSettled([
-        ...zoneRecordPromises,
-        nomenclaturePromise,
-      ]);
+      if (!(error instanceof SandreMdmTransientError)) {
+        controller.abort(attemptCancellation);
+      }
+      const settledResources = await Promise.allSettled(resourcePromises);
       const nonRetryableFailure = settledResources.find(
         (result): result is PromiseRejectedResult =>
           result.status === 'rejected' &&
@@ -3247,9 +3323,14 @@ export class ZoneAlerteService {
     budget: SandreMdmProofBudget,
   ): Promise<void> {
     await this.waitForSandreMdmDelay(
-      SANDRE_MDM_PROOF_RETRY_BASE_MS * 2 ** (attempt - 1),
+      Math.min(
+        SANDRE_MDM_PROOF_RETRY_BASE_MS *
+          2 ** Math.min(Math.max(0, attempt - 1), 3),
+        SANDRE_MDM_PROOF_RETRY_MAX_MS,
+      ),
       budget,
       budget.signal,
+      true,
     );
   }
 
@@ -3257,15 +3338,20 @@ export class ZoneAlerteService {
     delayMs: number,
     budget: SandreMdmProofBudget,
     signal?: AbortSignal,
+    fitWithinBudget = false,
   ): Promise<void> {
     if (signal?.aborted) {
       throw this.sandreMdmCancellationError(signal);
     }
     const remainingMs = budget.assertRemaining('before retry backoff');
-    if (delayMs >= remainingMs) {
-      throw new SandreMdmProofDeadlineExceededError(
-        'Sandre MDM proof deadline leaves no room for the required backoff',
-      );
+    let effectiveDelayMs = delayMs;
+    if (effectiveDelayMs >= remainingMs) {
+      if (!fitWithinBudget) {
+        throw new SandreMdmProofDeadlineExceededError(
+          'Sandre MDM proof deadline leaves no room for the required backoff',
+        );
+      }
+      effectiveDelayMs = Math.max(0, remainingMs - 1);
     }
     await new Promise<void>((resolve, reject) => {
       const onAbort = () => {
@@ -3276,7 +3362,7 @@ export class ZoneAlerteService {
       const timer = setTimeout(() => {
         signal?.removeEventListener('abort', onAbort);
         resolve();
-      }, delayMs);
+      }, effectiveDelayMs);
       signal?.addEventListener('abort', onAbort, { once: true });
     });
     budget.assertRemaining('after retry backoff');


### PR DESCRIPTION
## What changed

- retain each strictly validated MDM resource for the duration of one proof call
- retry only resources that are still missing until the existing 180 second wall-clock deadline
- let sibling reads finish after a transient failure, while still aborting immediately on validation drift
- preserve the pinned approval order and rebuild the full proof independently for audit and safe runs

## Why

The official MDM service currently returns rotating HTTP 500 responses. Retrying the whole four-resource proof discarded valid sibling responses, so no single attempt could converge even though each resource was intermittently available.

The accumulator is local and write-once. It does not persist between calls, weaken fingerprints, or open a database transaction while retrying.

## Validation

- backend-admin full Jest suite: 72 suites, 1063 tests passed, 60 conditionally skipped
- focused MDM and service tests: 115 passed
- Nest build passed
- targeted ESLint passed
- `git diff --check` passed
- independent review: no P0/P1/P2 findings
- live external proof completed in 30.689 s despite rotating 500 responses, with the expected three zone records and pinned nomenclature projection
